### PR TITLE
use strict

### DIFF
--- a/lib/cmd/config.js
+++ b/lib/cmd/config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const config = require('../utils/config'),
   logger = require('../utils/logger');
 

--- a/lib/cmd/export.js
+++ b/lib/cmd/export.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   options = require('../utils/shared-options'),
   config = require('../utils/config'),

--- a/lib/cmd/import.js
+++ b/lib/cmd/import.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   h = require('highland'),
   byline = require('byline'),

--- a/lib/cmd/lint.js
+++ b/lib/cmd/lint.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   chalk = require('chalk'),
   pluralize = require('pluralize'),

--- a/lib/cmd/touch.js
+++ b/lib/cmd/touch.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   clayUtils = require('clay-utils'),
   pluralize = require('pluralize'),

--- a/lib/io/agnostic-chunks.js
+++ b/lib/io/agnostic-chunks.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   b64 = require('base-64'),
   h = require('highland'),

--- a/lib/io/agnostic-chunks.test.js
+++ b/lib/io/agnostic-chunks.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const lib = require('./agnostic-chunks'),
   prefix = 'domain.com',
   foo = '/components/foo',

--- a/lib/io/input-clay.js
+++ b/lib/io/input-clay.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   h = require('highland'),
   clayUtils = require('clay-utils'),

--- a/lib/io/input-clay.test.js
+++ b/lib/io/input-clay.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const h = require('highland'),
   b64 = require('base-64'),
   rest = require('../utils/rest'),

--- a/lib/io/input-files.js
+++ b/lib/io/input-files.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path'),
   fs = require('fs-extra'),
   yaml = require('js-yaml'),

--- a/lib/io/input-files.test.js
+++ b/lib/io/input-files.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const isDirectory = require('is-directory'),
   glob = require('glob'),
   fs = require('fs-extra'),

--- a/lib/io/output-files.js
+++ b/lib/io/output-files.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   path = require('path'),
   fs = require('fs-extra'),

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const config = require('home-config'),
   expandHomeDir = require('expand-home-dir'),
   _ = require('lodash'),

--- a/lib/utils/config.test.js
+++ b/lib/utils/config.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const lib = require('./config'),
   config = require('home-config');
 

--- a/lib/utils/deep-reduce.js
+++ b/lib/utils/deep-reduce.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   clayUtils = require('clay-utils'),
   refProp = '_ref',

--- a/lib/utils/deep-reduce.test.js
+++ b/lib/utils/deep-reduce.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   lib = require('./deep-reduce'),
   refProp = '_ref',

--- a/lib/utils/fetch.js
+++ b/lib/utils/fetch.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fetch = require('node-fetch');
 
 /* istanbul ignore next */

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const consoleLog = require('console-log-level'),
   _ = require('lodash'),
   ora = require('ora'),

--- a/lib/utils/normalize-components.js
+++ b/lib/utils/normalize-components.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash'),
   refProp = '_ref';
 

--- a/lib/utils/normalize-components.test.js
+++ b/lib/utils/normalize-components.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const lib = require('./normalize-components');
 
 describe('normalize component data', () => {

--- a/lib/utils/rest.js
+++ b/lib/utils/rest.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const bluebird = require('bluebird'),
   h = require('highland'),
   _ = require('lodash'),

--- a/lib/utils/rest.test.js
+++ b/lib/utils/rest.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const h = require('highland'),
   lib = require('./rest'),
   fetch = require('./fetch'),

--- a/lib/utils/shared-options.js
+++ b/lib/utils/shared-options.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   verbose: {
     alias: 'verbose', // -v, --verbose

--- a/lib/utils/urls.js
+++ b/lib/utils/urls.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const nodeUrl = require('url'),
   _ = require('lodash'),
   types = [

--- a/lib/utils/urls.test.js
+++ b/lib/utils/urls.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const lib = require('./urls');
 
 describe('urls', () => {


### PR DESCRIPTION
because:

- strict mode helps catch bugs
- consistent semantics (some files were already strict)
- we're stuck on Node 4 in one of our branches and can't use
  clay-cli because of `let` not being allowed outside strict mode
  in Node 4's V8