### PR TITLE
Support import of @published pages

### DIFF
--- a/lib/io/input-clay.js
+++ b/lib/io/input-clay.js
@@ -253,6 +253,10 @@ function getDeepPage(concurrency, url) {
 
   return rest.get(url, concurrency)
     .flatMap((pageData) => {
+
+      // remove reserved properties that aren't URIs or URI arrays
+      pageData = _.omit(pageData, ['url', 'urlHistory', 'customUrl', 'lastModified', 'priority', 'changeFrequency']);
+
       const childUrls = _.reduce(pageData, (uris, area) => {
         if (_.isArray(area)) {
           return uris.concat(area);


### PR DESCRIPTION
[Related Trello](https://trello.com/c/Z0tqynOw/36-add-site-to-site-import-in-clay-cli)

Currently, an error is thrown if you attempt to import a published page. This is because clay-cli is currently written with the expectation that all the properties at the root of a page object are URIs or URI arrays. While this is true of draft pages, it is not true of published pages because the publishing process adds non-URI properties. These "page configuration" properties are specified in Amphora [here](https://github.com/clay/amphora/blob/master/lib/services/references.js#L166). This change modifies clay-cli to ignore these properties of the page object (except layout, which _is_ a URI).