### PR TITLE
Refactors rest utility so it doesn't break linting rules

### DIFF
--- a/lib/cmd/import.js
+++ b/lib/cmd/import.js
@@ -110,7 +110,12 @@ function importStream(prefix, argv) {
     .stopOnError(fatalError)
     // map agnostic chunks to data we can save
     .map(mapChunksToData(prefix))
-    .flatMap((item) => rest.put(item, key, argv.concurrency, _.includes(item.url, '/uris') ? 'text': 'json', headers))
+    .flatMap((item) => rest.put(item, {
+      key,
+      concurrency: argv.concurrency,
+      type: _.includes(item.url, '/uris') ? 'text' : 'json',
+      headers
+    }))
     .map(showProgress(argv))
     .toArray(showCompleted);
 }
@@ -131,7 +136,12 @@ function importSingleUrl(url, prefix, argv) {
   return clayInput.importUrl(url, argv.concurrency)
     .flatMap(chunks.replacePrefixes(prefix))
     .stopOnError(fatalError) // exit early if there's a problem reaching the input clay instance
-    .flatMap((item) => rest.put(item, key, argv.concurrency, 'json', headers))
+    .flatMap((item) => rest.put(item, {
+      key,
+      concurrency: argv.concurrency,
+      type: 'json',
+      headers
+    }))
     .map(showProgress(argv))
     .toArray(showCompleted);
 }
@@ -162,7 +172,12 @@ function importFile(filepath, prefix, argv) {
   .map(chunks.validate)
   // map agnostic chunks to data we can save
   .map(mapChunksToData(prefix))
-  .flatMap((item) => rest.put(item, key, argv.concurrency, _.includes(item.url, '/uris') ? 'text' : 'json', headers))
+  .flatMap((item) => rest.put(item, {
+    key,
+    concurrency: argv.concurrency,
+    type: _.includes(item.url, '/uris') ? 'text' : 'json',
+    headers
+  }))
   .map(showProgress(argv))
   .toArray(showCompleted);
 }

--- a/lib/cmd/touch.js
+++ b/lib/cmd/touch.js
@@ -19,7 +19,12 @@ function runLogic(prefix, name, argv) {
     headers = getYargHeaders(argv),
     published = argv.published,
     processSpinner = logger.startSpinner('Processing...'),
-    instancesStream = clay.getComponentInstances(prefix, name, concurrency, headers, published).stopOnError((err) => {
+    instancesStream = clay.getComponentInstances(prefix, name, {
+      concurrency,
+      headers,
+      onlyPublished: published
+    })
+    .stopOnError((err) => {
       logger.stopSpinner(processSpinner);
       logger.error(`Error resolving instances of ${name}!`, err.message);
     });

--- a/lib/cmd/touch.js
+++ b/lib/cmd/touch.js
@@ -40,7 +40,7 @@ function runLogic(prefix, name, argv) {
     instancesStream.flatMap((instances) => {
       const urls = _.map(instances, config.normalizeSite);
 
-      return rest.get(urls, concurrency, 'json', headers).stopOnError((err) => {
+      return rest.get(urls, {concurrency, headers}).stopOnError((err) => {
         logger.stopSpinner(processSpinner);
         logger.error(`Error resolving instance of ${name}!`, err.message);
       });

--- a/lib/io/input-clay.js
+++ b/lib/io/input-clay.js
@@ -44,7 +44,10 @@ function expandPropReferences(val) {
  * @return {Stream}
  */
 function getComponentInstances(prefix, name, concurrency, headers, onlyPublishedInstances) {
-  return rest.get(`${prefix}/components/${name}/instances${onlyPublishedInstances ? '/@published' : ''}`, concurrency, 'json', headers);
+  return rest.get(`${prefix}/components/${name}/instances${onlyPublishedInstances ? '/@published' : ''}`, {
+    concurrency,
+    headers
+  });
 }
 
 /**
@@ -90,7 +93,7 @@ function checkReference(concurrency, prefix, url) {
   url = urlUtil.uriToUrl(prefix, url);
 
   // todo: when HEAD requests are supported in amphora, simply call rest.check(url)
-  return rest.get(url, concurrency)
+  return rest.get(url, {concurrency})
     .map(() => ({ result: 'success' }))
     // we don't care about data, but we want the resulting stream's length
     // to be the number of urls we've checked
@@ -117,7 +120,7 @@ function recursivelyCheckReference(concurrency, prefix, uris) {
     return h([uris]);
   }
 
-  return rest.get(urls, concurrency)
+  return rest.get(urls, {concurrency})
     .flatMap((data) => {
       const childUris = listComponentReferences(data); // adding prefix when passed in recursively, so you don't need to do that here
 
@@ -139,7 +142,7 @@ function recursivelyCheckReference(concurrency, prefix, uris) {
  * @return {Stream} of { result: 'success or error', url (if error) }
  */
 function checkComponent(url, prefix, isRecursive, concurrency) {
-  const stream = rest.get(url, concurrency)
+  const stream = rest.get(url, {concurrency})
     .flatMap((data) => {
       const childUris = listComponentReferences(data);
 
@@ -163,7 +166,7 @@ function checkComponent(url, prefix, isRecursive, concurrency) {
  * @return {Stream} of { result: 'success or error', url (if error) }
  */
 function checkPage(url, prefix, isRecursive, concurrency) {
-  const stream = rest.get(url, concurrency)
+  const stream = rest.get(url, {concurrency})
     .flatMap((data) => {
       const layoutUri = data.layout,
         otherComponentUris = _.reduce(data, (uris, area) => {
@@ -201,7 +204,7 @@ function checkPublicUrl(url, prefix, isRecursive, concurrency) {
   }
 
   publicUrl = `${prefix}/uris/${b64.encode(urlUtil.urlToUri(url))}`;
-  return rest.get(publicUrl, concurrency, 'text')
+  return rest.get(publicUrl, {concurrency})
     .flatMap((pageUri) => {
       const pageUrl = urlUtil.uriToUrl(prefix, pageUri);
 
@@ -239,7 +242,7 @@ function checkAllReferences(uri, isRecursive, prefix, concurrency) {
  * @return {[type]}             [description]
  */
 function getDeepComponent(concurrency, url) {
-  return rest.get(`${url}.json`, concurrency, 'text')
+  return rest.get(`${url}.json`, {concurrency})
     .map((data) => ({ url, data }));
 }
 /**
@@ -251,7 +254,7 @@ function getDeepComponent(concurrency, url) {
 function getDeepPage(concurrency, url) {
   const prefix = urlUtil.getUrlPrefix(url).prefix;
 
-  return rest.get(url, concurrency)
+  return rest.get(url, {concurrency})
     .flatMap((pageData) => {
       const childUrls = _.reduce(pageData, (uris, area) => {
         if (_.isArray(area)) {

--- a/lib/io/input-clay.js
+++ b/lib/io/input-clay.js
@@ -38,13 +38,14 @@ function expandPropReferences(val) {
  * get list of instances in a component
  * @param  {string} prefix of site
  * @param  {string} name of component
- * @param {number} concurrency
+ * @param {object} [options]
+ * @param {number} [concurrency]
  * @param {object} [headers]
- * @param {boolean} [onlyPublishedInstances]
+ * @param {boolean} [onlyPublished]
  * @return {Stream}
  */
-function getComponentInstances(prefix, name, concurrency, headers, onlyPublishedInstances) {
-  return rest.get(`${prefix}/components/${name}/instances${onlyPublishedInstances ? '/@published' : ''}`, {
+function getComponentInstances(prefix, name, {concurrency, headers, onlyPublished} = {}) {
+  return rest.get(`${prefix}/components/${name}/instances${onlyPublished ? '/@published' : ''}`, {
     concurrency,
     headers
   });

--- a/lib/io/input-clay.test.js
+++ b/lib/io/input-clay.test.js
@@ -38,9 +38,9 @@ describe('input clay', () => {
 
     it('fetches published component instances', (done) => {
       rest.get.returns(h(['one']));
-      fn('domain.com', 'foo', 1, {headerKey: 'headerVal'}, true).collect().toCallback((err, data) => {
+      fn('domain.com', 'foo', {concurrency: 1, headers: {headerKey: 'headerVal'}, onlyPublished: true}).collect().toCallback((err, data) => {
         expect(data).to.eql(['one']);
-        expect(rest.get).to.have.been.calledWith('domain.com/components/foo/instances/@published', 1, 'json', {headerKey: 'headerVal'});
+        expect(rest.get).to.have.been.calledWith('domain.com/components/foo/instances/@published', {concurrency: 1, headers: {headerKey: 'headerVal'}});
         done(err);
       });
     });

--- a/lib/utils/config.test.js
+++ b/lib/utils/config.test.js
@@ -1,7 +1,7 @@
 const lib = require('./config'),
   config = require('home-config');
 
-describe('rest', () => {
+describe('config', () => {
   let sandbox;
 
   beforeEach(() => {

--- a/lib/utils/rest.js
+++ b/lib/utils/rest.js
@@ -3,9 +3,11 @@ const bluebird = require('bluebird'),
   _ = require('lodash'),
   fetch = require('./fetch'),
   logger = require('./logger'),
-  contentHeader = 'Content-Type',
-  contentJSON = 'application/json; charset=UTF-8',
-  contentText = 'text/plain; charset=UTF-8',
+  CONTENT_HEADER = 'Content-Type',
+  CONTENT_TYPES = {
+    text: 'text/plain; charset=UTF-8',
+    json: 'application/json; charset=UTF-8'
+  },
   DEFAULT_CONCURRENCY = 1; // note: argv.concurrency has a default of 10, so you should never be seeing requests go out at this value
 
 fetch.Promise = bluebird;
@@ -60,59 +62,72 @@ function createStream(items) {
  * get an array of urls
  * creates a stream with data from each url, or emits an error
  * @param  {Stream|array|string} urls array of urls or single url
- * @param {number} [concurrency]
- * @param {string} type 'json' or 'text'
- * @param {object} [headers]
+ * @param {object} [options]
+ * @param {number} [options.concurrency]
+ * @param {object} [options.headers]
  * @return {Stream}
  */
-function get(urls, concurrency, type, headers) {
-  type = type || 'json';
+function get(urls, {concurrency, headers}) {
   concurrency = concurrency || DEFAULT_CONCURRENCY;
-  return createStream(urls).map((url) => {
-    logger.debug(`GET ${url}`);
-    return h(send(url, {
+  return createStream(urls)
+    .map((url) => {
+      logger.debug(`GET ${url}`);
+      return h(send(url, {
         method: 'GET',
         headers: headers
       })
-      .then((res) => res[type]())
+      .then((res) => {
+        return _.startsWith(res.headers.get('content-type'), 'application/json') ?
+          res.json() :
+          res.text();
+      })
       .catch((e) => {
         e.url = url; // capture the url every time we error
         throw e;
       }));
-  }).mergeWithLimit(concurrency);
+    })
+    .mergeWithLimit(concurrency);
 }
 
 /**
  * put an array of items
  * @param  {Stream|array|object} items with { url: data }
- * @param {string} key
- * @param  {number} [concurrency]
- * @param {string} [type]
- * @param {object} [headers]
+ * @param {object} [options]
+ * @param {string} [options.key] authorization key of target resource
+ * @param {number} [options.concurrency]
+ * @param {object} [options.headers]
+ * @param {string} [options.type] "json" or "text"
  * @return {Stream}
  */
-function put(items, key, concurrency, type, headers) {
-  concurrency = concurrency || DEFAULT_CONCURRENCY;
-  type = type || 'json';
-  return createStream(items).map((item) => {
-    // each item should be { url, data: stringified }, e.g. if they're parsed by chunks.replacePrefixes
-    const url = item.url,
-      data = item.data;
+function put(items, {key, concurrency = DEFAULT_CONCURRENCY, headers, type}) {
+  return createStream(items)
+    .map((item) => {
+      // each item should be { url, data: stringified }, e.g. if they're parsed by chunks.replacePrefixes
+      const url = item.url,
+        data = item.data;
 
-    logger.debug(`PUT ${url}`);
-    return h(send(url, {
-      method: 'PUT',
-      body: data,
-      headers: Object.assign(
-        {
-          [contentHeader]: type === 'json' ? contentJSON : contentText,
-          Authorization: `Token ${key}`
-        },
+      headers = Object.assign({
+        'Content-Type': type === 'json' ? 'application/json; charset=UTF-8' : 'text/plain; charset=UTF-8',
+        Authorization: `Token ${key}`
+      }, headers);
+      logger.debug(`PUT ${url}`);
+      return h(send(url, {
+        method: 'PUT',
+        body: data,
         headers
-      )
-      // we don't care about the data returned from the put, but we do care it it worked or not
-    }).then(() => ({ result: 'success', url })).catch((e) => ({ result: 'error', url, message: e.message })));
-  }).mergeWithLimit(concurrency);
+        // we don't care about the data returned from the put, but we do care it it worked or not
+      })
+      .then(() => ({
+        result: 'success',
+        url
+      }))
+      .catch((e) => ({
+        result: 'error',
+        url,
+        message: e.message
+      })));
+    })
+    .mergeWithLimit(concurrency);
 }
 
 module.exports.get = get;

--- a/lib/utils/rest.js
+++ b/lib/utils/rest.js
@@ -3,10 +3,9 @@ const bluebird = require('bluebird'),
   _ = require('lodash'),
   fetch = require('./fetch'),
   logger = require('./logger'),
-  CONTENT_HEADER = 'Content-Type',
   CONTENT_TYPES = {
-    text: 'text/plain; charset=UTF-8',
-    json: 'application/json; charset=UTF-8'
+    json: 'application/json; charset=UTF-8',
+    text: 'text/plain; charset=UTF-8'
   },
   DEFAULT_CONCURRENCY = 1; // note: argv.concurrency has a default of 10, so you should never be seeing requests go out at this value
 
@@ -63,12 +62,12 @@ function createStream(items) {
  * creates a stream with data from each url, or emits an error
  * @param  {Stream|array|string} urls array of urls or single url
  * @param {object} [options]
- * @param {number} [options.concurrency]
+ * @param {number} [options.concurrency=1]
  * @param {object} [options.headers]
+ * @param {string} [options.type='json']
  * @return {Stream}
  */
-function get(urls, {concurrency, headers}) {
-  concurrency = concurrency || DEFAULT_CONCURRENCY;
+function get(urls, {concurrency = DEFAULT_CONCURRENCY, headers, type = 'json'} = {}) {
   return createStream(urls)
     .map((url) => {
       logger.debug(`GET ${url}`);
@@ -76,11 +75,7 @@ function get(urls, {concurrency, headers}) {
         method: 'GET',
         headers: headers
       })
-      .then((res) => {
-        return _.startsWith(res.headers.get('content-type'), 'application/json') ?
-          res.json() :
-          res.text();
-      })
+      .then(res => res[type]())
       .catch((e) => {
         e.url = url; // capture the url every time we error
         throw e;
@@ -94,12 +89,12 @@ function get(urls, {concurrency, headers}) {
  * @param  {Stream|array|object} items with { url: data }
  * @param {object} [options]
  * @param {string} [options.key] authorization key of target resource
- * @param {number} [options.concurrency]
+ * @param {number} [options.concurrency=1]
  * @param {object} [options.headers]
- * @param {string} [options.type] "json" or "text"
+ * @param {string} [options.type='text'] "json" or "text"
  * @return {Stream}
  */
-function put(items, {key, concurrency = DEFAULT_CONCURRENCY, headers, type}) {
+function put(items, {key = null, concurrency = DEFAULT_CONCURRENCY, headers, type = 'text'} = {}) {
   return createStream(items)
     .map((item) => {
       // each item should be { url, data: stringified }, e.g. if they're parsed by chunks.replacePrefixes
@@ -107,7 +102,7 @@ function put(items, {key, concurrency = DEFAULT_CONCURRENCY, headers, type}) {
         data = item.data;
 
       headers = Object.assign({
-        'Content-Type': type === 'json' ? 'application/json; charset=UTF-8' : 'text/plain; charset=UTF-8',
+        'Content-Type': CONTENT_TYPES[type],
         Authorization: `Token ${key}`
       }, headers);
       logger.debug(`PUT ${url}`);

--- a/lib/utils/rest.test.js
+++ b/lib/utils/rest.test.js
@@ -63,7 +63,7 @@ describe('rest', () => {
 
     it('gets text from url', (done) => {
       fetch.send.returns(Promise.resolve({ url, status: 200, text: () => 'hi'}));
-      fn(url, null, 'text').collect().toCallback((err, data) => {
+      fn(url, {key: null, type: 'text'}).collect().toCallback((err, data) => {
         expect(data).to.eql(['hi']);
         expect(fetch.send).to.have.been.calledWith(url);
         done(err);
@@ -96,7 +96,7 @@ describe('rest', () => {
       };
 
       fetch.send.returns(Promise.resolve({ url, status: 200, json: () => ({ a: 'b' })}));
-      fn(url, 1, 'json', mockHeaders).collect().toCallback((err, data) => {
+      fn(url, {concurrency: 1, type: 'json', headers: mockHeaders}).collect().toCallback((err, data) => {
         expect(fetch.send.getCall(0).calledWith(url, {
           method: 'GET',
           headers: mockHeaders
@@ -131,7 +131,7 @@ describe('rest', () => {
 
     it('puts text to url', (done) => {
       fetch.send.returns(Promise.resolve({ url, status: 200 }));
-      fn({ url, data: 'hi'}, null, 10, 'text').collect().toCallback((err, data) => {
+      fn({ url, data: 'hi'}, {key: null, concurrency: 10, type: 'text'}).collect().toCallback((err, data) => {
         expect(data).to.eql([{ result: 'success', url }]);
         expect(fetch.send).to.have.been.calledWith(url);
         done(err);
@@ -158,7 +158,7 @@ describe('rest', () => {
         };
 
       fetch.send.returns(Promise.resolve({ url, status: 200 }));
-      fn({ url, data: 'hi'}, null, 10, 'text', mockHeaders).collect().toCallback((err, data) => {
+      fn({ url, data: 'hi'}, {concurrency: 10, type: 'text', headers: mockHeaders}).collect().toCallback((err, data) => {
         expect(data).to.eql([{ result: 'success', url }]);
         expect(fetch.send.getCall(0).args).to.deep.equal([
           url,

--- a/lib/utils/rest.test.js
+++ b/lib/utils/rest.test.js
@@ -96,7 +96,7 @@ describe('rest', () => {
       };
 
       fetch.send.returns(Promise.resolve({ url, status: 200, json: () => ({ a: 'b' })}));
-      fn(url, {concurrency: 1, type: 'json', headers: mockHeaders}).collect().toCallback((err, data) => {
+      fn(url, {concurrency: 1, type: 'json', headers: mockHeaders}).collect().toCallback((err) => {
         expect(fetch.send.getCall(0).calledWith(url, {
           method: 'GET',
           headers: mockHeaders


### PR DESCRIPTION
Related somewhat to [Trello](https://trello.com/c/Z0tqynOw/36-add-site-to-site-import-in-clay-cli)

We've specified in our listing rules that a function may have no more than four arguments. As of #33, the rest utility breaks this rule. This PR mainly refactors the `get` and `put` fncs to organize all optional arguments under "options" objects and updates tests and dependents to reflect the new signatures.

... also corrects the test name for the config utility from "rest" to "config."