### PR TITLE
Ensures prefixes are replaced throughout composed component objects

### DIFF
--- a/lib/io/agnostic-chunks.js
+++ b/lib/io/agnostic-chunks.js
@@ -91,7 +91,7 @@ function addPrefix(prefix, uri) {
 function toggleListPrefixes(arr, fn) {
   if (_.has(_.head(arr), refProp)) {
     // it's a component list! strip the prefixes
-    return _.map(arr, (item) => _.assign({}, item, { [refProp]: fn(item[refProp]) }));
+    return _.map(arr, item => toggleReferencePrefixes(item, fn));
   } else if (_.isString(_.head(arr))) {
     // possibly a page list (array of strings)
     // note: other strings will just be passed through
@@ -111,7 +111,7 @@ function toggleListPrefixes(arr, fn) {
 function togglePropPrefixes(obj, fn) {
   if (_.has(obj, refProp)) {
     // it's a component prop! strip prefixes
-    return _.assign({}, obj, { [refProp]: fn(obj[refProp]) });
+    return toggleReferencePrefixes(obj, fn);
   } else {
     // just component data, move along
     return obj;


### PR DESCRIPTION
Page import gets a page's data and composes each component in that data (via the component's `.json` endpoint). For each component, the import process replaces the prefixes inside its data with the prefix for the target site and then PUTs that data to component's location in the target site.

However, the `replacePrefixes` step is not replacing all prefixes in a composed object because the replacement logic does not recursively apply to all the components within a component's component lists or component properties. As a result, components that are "grandchildren" of page-level components will appear with the _old_ prefixes after import.

This fix ensures the replacement operation applies recursively down a composed component.