### PR TITLE
Moves clayutils to regular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -333,7 +333,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/clayutils/-/clayutils-2.0.3.tgz",
       "integrity": "sha512-6oEhoGLV3UHwdXbybf/+R5wIffn36YSdHvKEvouZmm37VMaLEjI6aOWND/nTfsF3m5qAxUxTmJl1zrYnWoBGAg==",
-      "dev": true,
       "requires": {
         "glob": "7.1.2",
         "lodash": "4.17.4",
@@ -2067,7 +2066,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nymag-fs/-/nymag-fs-1.0.1.tgz",
       "integrity": "sha1-STkdL5fktYjNgSeImGqyH61afD4=",
-      "dev": true,
       "requires": {
         "glob": "7.1.2",
         "js-yaml": "3.8.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/nymag/clay-cli#readme",
   "devDependencies": {
     "chai": "^3.5.0",
-    "clayutils": "^2.0.3",
     "coveralls": "^2.13.1",
     "eslint": "^4.17.0",
     "istanbul": "^0.4.5",
@@ -45,6 +44,7 @@
     "bluebird": "^3.5.0",
     "byline": "^5.0.0",
     "chalk": "^1.1.3",
+    "clayutils": "^2.0.3",
     "console-log-level": "^1.4.0",
     "expand-home-dir": "0.0.3",
     "figures": "^2.0.0",


### PR DESCRIPTION
`claycli` is not working out-of-the-box via `npm install -g claycli` because `clayutils` is in dev dependencies when it should be in regular dependencies. This PR moves it to regular dependencies.