### PR TITLE
secret option to use nyan cat to show import progress instead of dots

### DIFF
--- a/lib/cmd/import.js
+++ b/lib/cmd/import.js
@@ -13,7 +13,8 @@ const _ = require('lodash'),
   rest = require('../utils/rest'),
   clayInput = require('../io/input-clay'),
   files = require('../io/input-files'),
-  getYargHeaders = require('../utils/headers').getYargHeaders;
+  getYargHeaders = require('../utils/headers').getYargHeaders,
+  progress = require('../utils/progress');
 
 /**
  * handle errors and exit when importer fails
@@ -53,6 +54,7 @@ function mapChunksToData(prefix) {
  * @return {function}
  */
 function showProgress(argv) {
+  progress.initCat();
   return (result) => {
     // verbose mode gives you the urls
     if (argv.verbose && result.result === 'success') {
@@ -61,9 +63,9 @@ function showProgress(argv) {
       logger.debug(`${chalk.red('✗')} PUT ${result.url}\n${result.message}`);
       // non-verbose mode just gives you dots
     } else if (result.result === 'success') {
-      process.stdout.write(chalk.green('.'));
+      progress.tick();
     } else if (result.result === 'error') {
-      process.stdout.write(chalk.red('.'));
+      progress.interrupt();
     }
     return result;
   };
@@ -77,14 +79,17 @@ function showCompleted(results) {
   const successes = _.filter(results, { result: 'success' }),
     errors = _.filter(results, { result: 'error' });
 
+  progress.end();
   process.stdout.write('\n'); // log BELOW the dots
   if (successes.length) {
     logger.success(`Imported ${pluralize('uri', successes.length, true)}!`);
   } else {
+    progress.end();
     logger.error('Imported 0 uris (´°ω°`)');
   }
 
   if (errors.length) {
+    progress.end();
     logger.warn(`Skipped ${pluralize('uri', errors.length, true)} due to errors:`, '\n' + _.map(errors, (error) => error.url).join('\n'));
   }
   logger.debug('Detailed Information:', '\n' + _.map(results, (result) => {

--- a/lib/utils/config.js
+++ b/lib/utils/config.js
@@ -8,7 +8,8 @@ const config = require('home-config'),
   sections = [
     'keys',
     'sites',
-    'files'
+    'files',
+    'toolConfig'
   ];
 
 /**

--- a/lib/utils/progress.js
+++ b/lib/utils/progress.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const chalk = require('chalk'),
+  config = require('./config'),
+  nyanCat = require('nyansole'),
+  isCat = config.get('toolConfig.nyancat'),
+  nyanProgress = isCat ? new nyanCat() : null;
+
+function initCat() {
+  if (isCat) {
+    nyanProgress.reset();
+    nyanProgress.start();
+  }
+}
+
+function tick() {
+  if (!isCat) {
+    process.stdout.write(chalk.green('.'));
+  }
+}
+
+function interrupt() {
+  if (!isCat) {
+    process.stdout.write(chalk.red('.'));
+  } else {
+    nyanProgress.stop();
+  }
+}
+
+function end() {
+  if (isCat) {
+    nyanProgress.end();
+  }
+}
+
+module.exports.end = end;
+module.exports.isCat = isCat;
+module.exports.interrupt = interrupt;
+module.exports.initCat = initCat;
+module.exports.tick = tick;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "js-yaml": "^3.8.4",
     "lodash": "^4.17.4",
     "node-fetch": "^1.6.3",
+    "nyansole": "^0.5.1",
     "ora": "^1.2.0",
     "pluralize": "^5.0.0",
     "replace-async": "^1.1.1",


### PR DESCRIPTION
I was totally serious about this.

![nyancat](https://user-images.githubusercontent.com/1952460/37793074-ff10e168-2de3-11e8-9170-c8d392c0ef6a.gif)

Add the following to your `.clayconfig` to use nyan cat to show import progress

```
[toolConfig]
nyancat = true
```