### PR TITLE
fix #66, add messaging when running commands against undefined urls

### DIFF
--- a/cli/export.js
+++ b/cli/export.js
@@ -44,6 +44,10 @@ function handler(argv) {
   let url = config.get('url', argv.url),
     isElasticPrefix, stream;
 
+  if (!url) {
+    fatalError({ url: 'URL is not defined!', message: 'Please specify a url to export from'}, argv);
+  }
+
   log('Exporting items...');
   stream = rest.isElasticPrefix(url).flatMap((isPrefix) => {
     isElasticPrefix = isPrefix;

--- a/cli/lint.js
+++ b/cli/lint.js
@@ -19,20 +19,9 @@ function builder(yargs) {
 function handler(argv) {
   const log = reporter.log(argv.reporter, 'lint');
 
-  if (argv.url) { // lint url
-    log('Linting url...');
-    return linter.lintUrl(argv.url)
-      .map(reporter.logAction(argv.reporter, 'lint'))
-      .toArray(reporter.logSummary(argv.reporter, 'lint', (successes, errors) => {
-        if (errors) {
-          return { success: false, message: `Missing ${pluralize('reference', errors, true)}`};
-        } else {
-          return { success: true, message: `All references exist! (checked ${pluralize('uri', successes, true)})` };
-        }
-      }));
-  } else { // lint schema from stdin
-    log('Linting schema...');
-    return getStdin().then((str) => {
+  return getStdin().then((str) => {
+    if (str) { // lint schema from stdin
+      log('Linting schema...');
       return linter.lintSchema(str)
         // no dot logging of individual schema linting, since it's just a single dot
         .toArray(reporter.logSummary(argv.reporter, 'lint', (successes, errors) => {
@@ -42,8 +31,19 @@ function handler(argv) {
             return { success: true, message: 'Schema has no issues' };
           }
         }));
-    });
-  }
+    } else { // lint url
+      log('Linting url...');
+      return linter.lintUrl(argv.url)
+        .map(reporter.logAction(argv.reporter, 'lint'))
+        .toArray(reporter.logSummary(argv.reporter, 'lint', (successes, errors) => {
+          if (errors) {
+            return { success: false, message: `Missing ${pluralize('reference', errors, true)}`};
+          } else {
+            return { success: true, message: `All references exist! (checked ${pluralize('uri', successes, true)})` };
+          }
+        }));
+    }
+  });
 }
 
 module.exports = {

--- a/lib/cmd/export.js
+++ b/lib/cmd/export.js
@@ -199,6 +199,14 @@ function fromURL(rawUrl, options = {}) {
   const concurrency = options.concurrency || DEFAULT_CONCURRENCY,
     url = config.get('url', rawUrl);
 
+  if (!url) {
+    let e = new Error('URL is not defined! Please specify a url to export from');
+
+    e.url = 'undefined url';
+    // exit early if there's no url
+    return h.fromError(e);
+  }
+
   let prefix, stream;
 
   try {
@@ -234,20 +242,31 @@ function fromURL(rawUrl, options = {}) {
 function fromQuery(rawUrl, query = {}, options = {}) {
   const concurrency = options.concurrency || DEFAULT_CONCURRENCY,
     key = config.get('key', options.key),
-    prefix = config.get('url', rawUrl),
-    fullQuery = _.assign({
-      index: 'pages',
-      size: 10,
-      body: {
-        query: {
-          prefix: {
-            uri: prefixes.urlToUri(prefix)
-          }
+    prefix = config.get('url', rawUrl);
+
+  let fullQuery, stream;
+
+  if (!prefix) {
+    let e = new Error('URL is not defined! Please specify a site prefix to export from');
+
+    e.url = 'undefined prefix';
+    // exit early if there's no url
+    return h.fromError(e);
+  }
+
+  fullQuery = _.assign({
+    index: 'pages',
+    size: 10,
+    body: {
+      query: {
+        prefix: {
+          uri: prefixes.urlToUri(prefix)
         }
       }
-    }, { size: options.size }, query);
+    }
+  }, { size: options.size }, query);
 
-  let stream = rest.query(`${prefix}/_search`, fullQuery, { key })
+  stream = rest.query(`${prefix}/_search`, fullQuery, { key })
     .map(toError)
     .flatMap((res) => {
       return h(_.map(res.data, (item) => generateExportStream(prefixes.uriToUrl(prefix, item._id), prefix, options.layout))).flatten();

--- a/lib/cmd/export.test.js
+++ b/lib/cmd/export.test.js
@@ -8,6 +8,12 @@ describe('export', () => {
   });
 
   describe('fromURL', () => {
+    it('errors if no url defined', () => {
+      return lib.fromURL(null, { yaml: true, concurrency }).collect().toPromise(Promise).catch((e) => {
+        expect(e.message).toBe('URL is not defined! Please specify a url to export from');
+      });
+    });
+
     it('exports bootstrap stream', () => {
       fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
       return lib.fromURL('http://domain.com/_components/foo', { yaml: true, concurrency }).collect().toPromise(Promise).then((res) => {
@@ -219,6 +225,12 @@ describe('export', () => {
 
     it('throws error if no api key specified', () => {
       expect(() => lib.fromQuery(prefix)).toThrow('Please specify API key to do POST requests against Clay!');
+    });
+
+    it('streams error if no url defined', () => {
+      return lib.fromQuery(null, {}, { yaml: true, concurrency }).collect().toPromise(Promise).catch((e) => {
+        expect(e.message).toBe('URL is not defined! Please specify a site prefix to export from');
+      });
     });
 
     it('streams error if no results found', () => {

--- a/lib/cmd/import.js
+++ b/lib/cmd/import.js
@@ -90,6 +90,11 @@ function importItems(str, url, options = {}) {
     key = config.get('key', options.key),
     prefix = config.get('url', url);
 
+  if (!prefix) {
+    // exit early if there's no url
+    return h.of({ type: 'error', message: 'URL is not defined! Please specify a site prefix to import to' });
+  }
+
   if (options.yaml) {
     // parse bootstraps
     return (_.isString(str) ? h.of(str) : h(str))

--- a/lib/cmd/import.test.js
+++ b/lib/cmd/import.test.js
@@ -11,6 +11,12 @@ describe('import', () => {
     fetch.resetMocks();
   });
 
+  it('returns error if no url', () => {
+    return lib('abc').toPromise(Promise).then((res) => {
+      expect(res).toEqual({ type: 'error', message: 'URL is not defined! Please specify a site prefix to import to' });
+    });
+  });
+
   it('returns error if not JSON', () => {
     return lib('abc', url).toPromise(Promise).then((res) => {
       expect(res).toEqual({ type: 'error', message: 'Cannot import dispatch from yaml', details: 'Please use the --yaml argument to import from bootstraps' });

--- a/lib/cmd/lint.js
+++ b/lib/cmd/lint.js
@@ -170,6 +170,11 @@ function lintUrl(rawUrl, options = {}) {
   const concurrency = options.concurrency || DEFAULT_CONCURRENCY,
     url = config.get('url', rawUrl);
 
+  if (!url) {
+    // exit early if there's no url
+    return h.of({ type: 'error', message: 'URL is not defined! Please specify a url to lint' });
+  }
+
   if (utils.isComponent(url)) {
     return checkComponent(url, prefixes.getFromUrl(url), concurrency);
   } else if (utils.isPage(url)) {

--- a/lib/cmd/lint.test.js
+++ b/lib/cmd/lint.test.js
@@ -9,6 +9,12 @@ describe('lint', () => {
   });
 
   describe('lintUrl', () => {
+    it('returns error if no url', () => {
+      return lib.lintUrl().toPromise(Promise).then((res) => {
+        expect(res).toEqual({ type: 'error', message: 'URL is not defined! Please specify a url to lint' });
+      });
+    });
+
     it('lints with default concurrency', () => {
       fetch.mockResponseOnce('{}');
       return lib.lintUrl('domain.com/_components/foo/instances/bar').toPromise(Promise).then((res) => {


### PR DESCRIPTION
this adds specific error messaging when running claycli commands against urls, when you forget to type in the url (and don't have it set in `CLAYCLI_DEFAULT_URL`)

* import now pipes error and exits early
* export now pipes error and exits early
* lint pipes error