### PR TITLE
improve dev quality of life by .0001%

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ You may also specify with reporter to use by setting the `CLAYCLI_REPORTER` envi
 export CLAYCLI_REPORTER=json
 ```
 
+`claycli` pipes to `stderr`.
+
+```bash
+`clay lint --reporter json domain.com/_components/article 2> article-log.json`
+```
+
 ## Handling Files
 
 ### Dispatch

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You may also specify with reporter to use by setting the `CLAYCLI_REPORTER` envi
 export CLAYCLI_REPORTER=json
 ```
 
-`claycli` pipes to `stderr`.
+`claycli` pipes to `stderr`. If you want to pipe the logs to a file or another command, you may use `2>`.
 
 ```bash
 `clay lint --reporter json domain.com/_components/article 2> article-log.json`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You may also specify with reporter to use by setting the `CLAYCLI_REPORTER` envi
 export CLAYCLI_REPORTER=json
 ```
 
-`claycli` pipes to `stderr`. If you want to pipe the logs to a file or another command, you may use `2>`.
+`claycli` pipes to `stderr`. If you want to pipe the logs to a file, you may use `2>`.
 
 ```bash
 `clay lint --reporter json domain.com/_components/article 2> article-log.json`


### PR DESCRIPTION
let people know that clay outputs logs via `stderr`