### PR TITLE
Lint by extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ clay lint [--concurrency <number>] [url]
 
 Verify Clay data against standardized conventions and make sure all child components exist.
 
-Linting a page, component, or user url will verify that the data for that url exists, and (for pages and components) will (recursively) verify that all references to child components exist. The url must be a raw url, an alias specified via `clay config`, or omitted in favor of `CLAYCLI_DEFAULT_URL`.
+Linting a page, component, or user url will verify that the data for that url exists, and (for pages and components) will (recursively) verify that all references to child components exist. The url must be a raw url, an alias specified via `clay config`, or omitted in favor of `CLAYCLI_DEFAULT_URL`. Linting a public url (or a page/component url that has a `.html` extension) will attempt to render that url with the extension and, if that fails, try to figure out which component isn't rendering correctly. You may lint other renderers by providing their extensions, e.g. `.amp` or `.rss`.
 
 Instead of linting a url, you may pipe in a component's `schema.yml` to lint. It will go through the schema and verify that it conforms to [Kiln's schema rules](https://claycms.gitbooks.io/kiln/editing-components.html).
 
@@ -172,6 +172,7 @@ Instead of linting a url, you may pipe in a component's `schema.yml` to lint. It
 ```bash
 clay lint domain.com/_pages/123 # lint all components on a page
 clay lint domain.com/2018/02/some-slug.html # lint a page via public url
+clay lint domain.com/_components/article/instances/abc.html # lint a component and its html
 clay lint my-cool-article # lint a component specified via config alias
 clay lint < components/article/schema.yml # lint single schema
 ```

--- a/lib/cmd/lint.js
+++ b/lib/cmd/lint.js
@@ -129,7 +129,8 @@ function checkComponent(url, prefix, concurrency, ext = '') {
                   return h([
                     h.of({ type: 'error', message: `${url}${ext}` }), // the .ext errored,
                     h.of({ type: 'success', message: url }), // but the data succeeded
-                    h(children)]).merge(); // which means it's either this template or a child that's breaking it
+                    h(children)
+                  ]).merge(); // which means it's either this template or a child that's breaking it
                 })
                 .errors(pushRestError)
                 .flatMap((uri) => checkComponent(uri, prefix, concurrency, ext))
@@ -153,6 +154,13 @@ function checkComponent(url, prefix, concurrency, ext = '') {
  * @return {Stream}
  */
 function checkPage(url, prefix, concurrency) {
+  let ext = '';
+
+  // if we're checking a page with an extension, cut it off from the url and pass it into the component checking
+  if (_.isString(url) && prefixes.getExt(url)) {
+    ext = prefixes.getExt(url);
+    url = url.slice(0, url.indexOf(ext));
+  }
   // first, do a quick check against the composed json
   return rest.get(`${url}.json`)
     .flatMap((res) => {
@@ -167,8 +175,34 @@ function checkPage(url, prefix, concurrency) {
             return h([h.of({ type: 'success', message: url }), h.of(layout), h(children)]).merge();
           })
           .errors(pushRestError)
-          .flatMap((uri) => checkComponent(uri, prefix))
+          .flatMap((uri) => checkComponent(uri, prefix, concurrency, ext))
           .ratelimit(concurrency, CONCURRENCY_TIME);
+      } else if (ext.length) {
+        // data is fine, check the rendered version
+        return rest.get(`${url}${ext}`, { type: 'text' })
+          .flatMap((res) => {
+            if (res instanceof Error) {
+              // render is broken, start checking children
+              return rest.get(url)
+                .map(toError)
+                .flatMap((data) => {
+                  const layout = data.layout,
+                    children = _.reduce(data, (uris, area) => _.isArray(area) ? uris.concat(area) : uris, []);
+
+                  return h([
+                    h.of({ type: 'error', message: `${url}${ext}` }), // the .ext errored,
+                    h.of({ type: 'success', message: url }), // but the data succeeded
+                    h.of(layout), // which means either the layout
+                    h(children) // or the children are broken
+                  ]).merge();
+                })
+                .errors(pushRestError)
+                .flatMap((uri) => checkComponent(uri, prefix, concurrency, ext))
+                .ratelimit(concurrency, CONCURRENCY_TIME);
+            } else {
+              return h.of({ type: 'success', message: `${url}${ext}` });
+            }
+          });
       } else {
         // everything's fine! no need to lint any children
         return h.of({ type: 'success', message: url });
@@ -188,7 +222,7 @@ function checkPublicUrl(url, concurrency) {
     .flatMap(({ uri, prefix }) => {
       const pageURL = prefixes.uriToUrl(prefix, uri);
 
-      return h([h.of({ type: 'success', message: url }), checkPage(pageURL, prefix, concurrency)]).merge();
+      return h([h.of({ type: 'success', message: url }), checkPage(`${pageURL}.html`, prefix, concurrency)]).merge();
     }).errors(pushRestError);
 }
 

--- a/lib/cmd/lint.js
+++ b/lib/cmd/lint.js
@@ -81,11 +81,10 @@ function pushRestError(err, push) {
  * @param  {*} url
  * @param {string} prefix
  * @param  {number} concurrency
+ * @param {string} ext
  * @return {Stream}
  */
-function checkComponent(url, prefix, concurrency) {
-  const ext = _.isString(url) && prefixes.getExt(url) ? prefixes.getExt(url) : '';
-
+function checkComponent(url, prefix, concurrency, ext = '') {
   if (_.isObject(url)) {
     return h.of(url); // error / success object, pass it on
   } else if (_.isString(url) && !_.includes(url, 'http')) {
@@ -93,8 +92,11 @@ function checkComponent(url, prefix, concurrency) {
     url = prefixes.uriToUrl(prefix, url);
   }
 
-  // remove extension to check against composed json, then check with the extension afterwards
-  if (ext.length) {
+  // if extension has been passed in (with a uri), make sure we keep checking it
+  // otherwise, check the url for an extension, then...
+  // remove extension from the url to check against composed json, then check with the extension afterwards
+  if (!ext.length && _.isString(url) && prefixes.getExt(url)) {
+    ext = prefixes.getExt(url);
     url = url.slice(0, url.indexOf(ext));
   }
 
@@ -111,7 +113,7 @@ function checkComponent(url, prefix, concurrency) {
             return h([h.of({ type: 'success', message: url }), h(children)]).merge();
           })
           .errors(pushRestError)
-          .flatMap((uri) => checkComponent(`${uri}${ext}`, prefix))
+          .flatMap((uri) => checkComponent(uri, prefix, concurrency, ext))
           .ratelimit(concurrency, CONCURRENCY_TIME);
       } else if (ext.length) {
         // data is fine, check the rendered version
@@ -124,10 +126,13 @@ function checkComponent(url, prefix, concurrency) {
                 .flatMap((data) => {
                   const children = listComponentReferences(data);
 
-                  return h([h.of({ type: 'success', message: url }), h(children)]).merge();
+                  return h([
+                    h.of({ type: 'error', message: `${url}${ext}` }), // the .ext errored,
+                    h.of({ type: 'success', message: url }), // but the data succeeded
+                    h(children)]).merge(); // which means it's either this template or a child that's breaking it
                 })
                 .errors(pushRestError)
-                .flatMap((uri) => checkComponent(`${uri}${ext}`, prefix))
+                .flatMap((uri) => checkComponent(uri, prefix, concurrency, ext))
                 .ratelimit(concurrency, CONCURRENCY_TIME);
             } else {
               return h.of({ type: 'success', message: `${url}${ext}` });

--- a/lib/cmd/lint.js
+++ b/lib/cmd/lint.js
@@ -84,11 +84,18 @@ function pushRestError(err, push) {
  * @return {Stream}
  */
 function checkComponent(url, prefix, concurrency) {
+  const ext = _.isString(url) && prefixes.getExt(url) ? prefixes.getExt(url) : '';
+
   if (_.isObject(url)) {
     return h.of(url); // error / success object, pass it on
   } else if (_.isString(url) && !_.includes(url, 'http')) {
     // uri, convert it to url
     url = prefixes.uriToUrl(prefix, url);
+  }
+
+  // remove extension to check against composed json, then check with the extension afterwards
+  if (ext.length) {
+    url = url.slice(0, url.indexOf(ext));
   }
 
   // first, do a quick check against the composed json
@@ -104,11 +111,31 @@ function checkComponent(url, prefix, concurrency) {
             return h([h.of({ type: 'success', message: url }), h(children)]).merge();
           })
           .errors(pushRestError)
-          .flatMap((uri) => checkComponent(uri, prefix))
+          .flatMap((uri) => checkComponent(`${uri}${ext}`, prefix))
           .ratelimit(concurrency, CONCURRENCY_TIME);
+      } else if (ext.length) {
+        // data is fine, check the rendered version
+        return rest.get(`${url}${ext}`, { type: 'text' })
+          .flatMap((res) => {
+            if (res instanceof Error) {
+              // render is broken, start checking children
+              return rest.get(url)
+                .map(toError)
+                .flatMap((data) => {
+                  const children = listComponentReferences(data);
+
+                  return h([h.of({ type: 'success', message: url }), h(children)]).merge();
+                })
+                .errors(pushRestError)
+                .flatMap((uri) => checkComponent(`${uri}${ext}`, prefix))
+                .ratelimit(concurrency, CONCURRENCY_TIME);
+            } else {
+              return h.of({ type: 'success', message: `${url}${ext}` });
+            }
+          });
       } else {
         // everything's fine! no need to lint any children
-        return h.of({ type: 'success', message: url });
+        return h.of({ type: 'success', message: `${url}${ext}` });
       }
     });
 }

--- a/lib/cmd/lint.test.js
+++ b/lib/cmd/lint.test.js
@@ -152,6 +152,23 @@ describe('lint', () => {
       });
     });
 
+    it('lints an existing page with existing children with broken template', () => {
+      fetch.mockResponseOnce('{}'); // page .json
+      fetch.mockResponseOnce('html', { status: 500 }); // page .html
+      fetch.mockResponseOnce(JSON.stringify({
+        layout: 'domain.com/_components/foo/instances/bar',
+        main: ['domain.com/_components/bar/instances/baz']
+      })); // page data
+      fetch.mockResponseOnce('{}'); // layout .json
+      fetch.mockResponseOnce('html', { status: 500 }); // layout html
+      fetch.mockResponseOnce('{}'); // layout data
+      fetch.mockResponseOnce('{}'); // main .json
+      fetch.mockResponseOnce('html'); // main .html
+      return lib.lintUrl('domain.com/_pages/foo.html', {concurrency}).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ type: 'error', message: 'http://domain.com/_pages/foo.html' }, { type: 'success', message: 'http://domain.com/_pages/foo' }, { type: 'error', message: 'http://domain.com/_components/foo/instances/bar.html' }, { type: 'success', message: 'http://domain.com/_components/foo/instances/bar' }, { type: 'success', message: 'http://domain.com/_components/bar/instances/baz.html' }]);
+      });
+    });
+
     it('lints an existing page with non-existing children', () => {
       fetch.mockResponseOnce('{}', { status: 404 }); // page .json
       fetch.mockResponseOnce(JSON.stringify({
@@ -167,10 +184,29 @@ describe('lint', () => {
     });
 
     it('lints an existing public url with existing children', () => {
-      fetch.mockResponseOnce('domain.com/_pages/foo');
-      fetch.mockResponseOnce(JSON.stringify('{}'));
+      fetch.mockResponseOnce('domain.com/_pages/foo'); // uris
+      fetch.mockResponseOnce(JSON.stringify('{}')); // page .json
+      fetch.mockResponseOnce('html'); // page .html
       return lib.lintUrl('domain.com/some-slug', {concurrency}).collect().toPromise(Promise).then((res) => {
-        expect(res).toEqual([{ type: 'success', message: 'http://domain.com/some-slug' }, { type: 'success', message: 'http://domain.com/_pages/foo' }]);
+        expect(res).toEqual([{ type: 'success', message: 'http://domain.com/some-slug' }, { type: 'success', message: 'http://domain.com/_pages/foo.html' }]);
+      });
+    });
+
+    it('lints an existing public url with existing children with broken template', () => {
+      fetch.mockResponseOnce('domain.com/_pages/foo'); // uris
+      fetch.mockResponseOnce('{}'); // page .json
+      fetch.mockResponseOnce('html', { status: 500 }); // page .html
+      fetch.mockResponseOnce(JSON.stringify({
+        layout: 'domain.com/_components/foo/instances/bar',
+        main: ['domain.com/_components/bar/instances/baz']
+      })); // page data
+      fetch.mockResponseOnce('{}'); // layout .json
+      fetch.mockResponseOnce('html', { status: 500 }); // layout html
+      fetch.mockResponseOnce('{}'); // layout data
+      fetch.mockResponseOnce('{}'); // main .json
+      fetch.mockResponseOnce('html'); // main .html
+      return lib.lintUrl('domain.com/some-slug', {concurrency}).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ type: 'success', message: 'http://domain.com/some-slug' }, { type: 'error', message: 'http://domain.com/_pages/foo.html' }, { type: 'success', message: 'http://domain.com/_pages/foo' }, { type: 'error', message: 'http://domain.com/_components/foo/instances/bar.html' }, { type: 'success', message: 'http://domain.com/_components/foo/instances/bar' }, { type: 'success', message: 'http://domain.com/_components/bar/instances/baz.html' }]);
       });
     });
   });

--- a/lib/cmd/lint.test.js
+++ b/lib/cmd/lint.test.js
@@ -29,10 +29,36 @@ describe('lint', () => {
       });
     });
 
+    it('lints an existing component with extension, without children', () => {
+      fetch.mockResponseOnce('{}'); // .json
+      fetch.mockResponseOnce('html'); // .html
+      return lib.lintUrl('domain.com/_components/foo/instances/bar.html', {concurrency}).toPromise(Promise).then((res) => {
+        expect(res).toEqual({ type: 'success', message: 'http://domain.com/_components/foo/instances/bar.html' });
+      });
+    });
+
+    it('lints an existing component with broken template, without children', () => {
+      fetch.mockResponseOnce('{}'); // .json
+      fetch.mockResponseOnce('nope', { status: 500 }); // .html
+      fetch.mockResponseOnce('{}'); // data
+      return lib.lintUrl('domain.com/_components/foo/instances/bar.html', {concurrency}).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ type: 'error', message: 'http://domain.com/_components/foo/instances/bar.html' }, { type: 'success', message: 'http://domain.com/_components/foo/instances/bar' }]);
+      });
+    });
+
     it('lints a non-existing component without children', () => {
       fetch.mockResponseOnce('{}', { status: 404 }); // .json
       fetch.mockResponseOnce('{}', { status: 404 }); // non-composed data
       return lib.lintUrl('domain.com/_components/foo/instances/bar', {concurrency}).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ type: 'error', message: 'http://domain.com/_components/foo/instances/bar' }]);
+      });
+    });
+
+    it('lints a non-existing component with extension, without children', () => {
+      fetch.mockResponseOnce('{}', { status: 404 }); // .json
+      fetch.mockResponseOnce('{}', { status: 404 }); // non-composed data
+      // note: no call for rendered stuff, as the data failed
+      return lib.lintUrl('domain.com/_components/foo/instances/bar.html', {concurrency}).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([{ type: 'error', message: 'http://domain.com/_components/foo/instances/bar' }]);
       });
     });
@@ -43,6 +69,27 @@ describe('lint', () => {
       fetch.mockResponseOnce('{}'); // child
       return lib.lintUrl('domain.com/_components/foo/instances/bar', {concurrency}).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_components/foo/instances/bar' }, { type: 'success', message: 'http://domain.com/_components/some-child' }]);
+      });
+    });
+
+    it('lints a component with extension, with existing children', () => {
+      fetch.mockResponseOnce('{}', { status: 404 }); // .json
+      fetch.mockResponseOnce(JSON.stringify({ a: { _ref: 'domain.com/_components/some-child' }, b: { prop: true }, c: 'd' }));
+      fetch.mockResponseOnce('{}'); // child .json
+      fetch.mockResponseOnce('html'); // child .html
+      return lib.lintUrl('domain.com/_components/foo/instances/bar.html', {concurrency}).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_components/foo/instances/bar' }, { type: 'success', message: 'http://domain.com/_components/some-child.html' }]);
+      });
+    });
+
+    it('lints a component with extension, with existing children with broken template', () => {
+      fetch.mockResponseOnce('{}', { status: 404 }); // .json
+      fetch.mockResponseOnce(JSON.stringify({ a: { _ref: 'domain.com/_components/some-child' }, b: { prop: true }, c: 'd' }));
+      fetch.mockResponseOnce('{}'); // child .json
+      fetch.mockResponseOnce('html', { status: 500 }); // child .html
+      fetch.mockResponseOnce('{}'); // child data
+      return lib.lintUrl('domain.com/_components/foo/instances/bar.html', {concurrency}).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_components/foo/instances/bar' }, { type: 'error', message: 'http://domain.com/_components/some-child.html' }, { type: 'success', message: 'http://domain.com/_components/some-child' }]);
       });
     });
 
@@ -61,6 +108,16 @@ describe('lint', () => {
       fetch.mockResponseOnce('{}', { status: 404 }); // child .json
       fetch.mockResponseOnce('{}', { status: 404 }); // child
       return lib.lintUrl('domain.com/_components/foo/instances/bar', {concurrency}).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_components/foo/instances/bar' }, { type: 'error', message: 'http://domain.com/_components/some-child' }]);
+      });
+    });
+
+    it('lints a component with extension, with non-existing children', () => {
+      fetch.mockResponseOnce('{}', { status: 404 }); // .json
+      fetch.mockResponseOnce(JSON.stringify({ a: { _ref: 'domain.com/_components/some-child' } }));
+      fetch.mockResponseOnce('{}', { status: 404 }); // child .json
+      fetch.mockResponseOnce('{}', { status: 404 }); // child
+      return lib.lintUrl('domain.com/_components/foo/instances/bar.html', {concurrency}).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_components/foo/instances/bar' }, { type: 'error', message: 'http://domain.com/_components/some-child' }]);
       });
     });

--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -5,13 +5,7 @@ const h = require('highland'),
   utils = require('clayutils'),
   composer = require('./composer'),
   deepReduce = require('./deep-reduce'),
-  types = [
-    '/_components',
-    '/_pages',
-    '/_users',
-    '/_uris',
-    '/_lists'
-  ];
+  types = require('./types');
 
 /**
  * get uri from dispatch

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -4,13 +4,7 @@ const _ = require('lodash'),
   replace = require('string-replace-async'),
   h = require('highland'),
   b64 = require('base-64'),
-  types = [
-    '/_components',
-    '/_pages',
-    '/_users',
-    '/_uris',
-    '/_lists'
-  ];
+  types = require('./types');
 
 /**
  * add prefixes

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -108,8 +108,24 @@ function urlToUri(url) {
   return parts.hostname + path;
 }
 
+/**
+ * get extension from url
+ * @param  {string} url
+ * @return {string|null} e.g. '.json' or '.html'
+ */
+function getExt(url) {
+  const parts = nodeUrl.parse(url);
+
+  if (_.includes(parts.pathname, '.')) {
+    return parts.pathname.slice(parts.pathname.indexOf('.'));
+  } else {
+    return null;
+  }
+}
+
 module.exports.add = add;
 module.exports.remove = remove;
 module.exports.getFromUrl = getFromUrl;
 module.exports.uriToUrl = uriToUrl;
 module.exports.urlToUri = urlToUri;
+module.exports.getExt = getExt;

--- a/lib/prefixes.test.js
+++ b/lib/prefixes.test.js
@@ -237,4 +237,14 @@ describe('prefixes', () => {
       expect(lib.urlToUri('http://domain.com/_components/foo.json')).toBe('domain.com/_components/foo');
     });
   });
+
+  describe('getExt', () => {
+    it('returns null if no prefix', () => {
+      expect(lib.getExt('http://domain.com/_components/foo')).toBe(null);
+    });
+
+    it('returns extension', () => {
+      expect(lib.getExt('http://domain.com/_components/foo.html')).toBe('.html');
+    });
+  });
 });

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -1,6 +1,5 @@
 'use strict';
-const fetch = require('isomorphic-fetch'),
-  h = require('highland'),
+const h = require('highland'),
   _ = require('lodash'),
   nodeUrl = require('url'),
   https = require('https'),
@@ -11,6 +10,9 @@ const fetch = require('isomorphic-fetch'),
     json: 'application/json; charset=UTF-8',
     text: 'text/plain; charset=UTF-8'
   };
+
+// isormorphic-fetch sets a global
+require('isomorphic-fetch');
 
 /**
  * get protocol to determine if we need https agent

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// all types of data
+module.exports = [
+  '/_components',
+  '/_pages',
+  '/_users',
+  '/_uris',
+  '/_lists'
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,12 @@
         "js-tokens": "3.0.2"
       }
     },
+    "@types/jest": {
+      "version": "23.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.1.4.tgz",
+      "integrity": "sha512-w2KaQFm8zaZMsvPGYWoCxvpDli+dXhee2QZCk35sCpG595KKinyxfpKlfvxZWH776K2kPk53AgO5zv+U4JIrdg==",
+      "dev": true
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -3361,12 +3367,14 @@
       }
     },
     "jest-fetch-mock": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-1.4.2.tgz",
-      "integrity": "sha512-CLCrS6jeuoFu858Fe6XJWIrEF2hktS7cmbuBQyv+DJem/z4BLgpmxuYYqhH2F7ynNMIxXtE451gau3Lxc6gwsA==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-1.6.5.tgz",
+      "integrity": "sha512-qPz5Zf8+W16pu6cvdwXkb2SwRfxGoQbbGB6HcIBFND0gnWKMfQilZew3PSODnOWQZF/pzBPi7ZIT6Yz5D0va1Q==",
       "dev": true,
       "requires": {
-        "isomorphic-fetch": "2.2.1"
+        "@types/jest": "23.1.4",
+        "isomorphic-fetch": "2.2.1",
+        "promise-polyfill": "7.1.2"
       }
     },
     "jest-get-type": {
@@ -4418,6 +4426,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "promise-polyfill": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
+      "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
       "dev": true
     },
     "pseudomap": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "watch": "jest --watch"
   },
   "jest": {
+    "automock": false,
     "collectCoverage": true,
     "collectCoverageFrom": [
       "**/*.js",
@@ -47,7 +48,7 @@
     "coveralls": "^3.0.0",
     "eslint": "^4.17.0",
     "jest": "^22.4.1",
-    "jest-fetch-mock": "^1.4.2"
+    "jest-fetch-mock": "^1.6.5"
   },
   "dependencies": {
     "base-64": "^0.1.0",


### PR DESCRIPTION
* allows linting components, pages, and public urls by extension
* note: this changes the public url linting to _also_ check the `.html` rendered page
* note: this still checks recursively, so children's templates will also be linted
* note: you may lint against _any_ extension, not just `.html`, e.g. `domain.com/_components/my-cool-feed.rss`

![screen shot 2018-07-05 at 12 09 43 pm](https://user-images.githubusercontent.com/447522/42334816-57b35476-804c-11e8-9598-cb3d38ff916a.png)
