### PR TITLE
_layouts and metadata

### DIFF
--- a/lib/cmd/export.js
+++ b/lib/cmd/export.js
@@ -12,15 +12,6 @@ const _ = require('lodash'),
 let layouts = []; // keep track of exported layouts, to dedupe the dispatches
 
 /**
- * determine if a uri is a default layout uri
- * @param  {string}  uri
- * @return {Boolean}
- */
-function isDefaultLayout(uri) {
-  return _.isString(uri) && !!uri.match(/\/_layouts\/[A-Za-z0-9\-]+$/);
-}
-
-/**
  * throw errors in the same place they can be dealt with
  * note: in the programmatic api, you need to handle errors yourself
  * because the stream will be pure data
@@ -174,7 +165,7 @@ function exportPublicURL(url, includeLayout) {
  * @return {Stream}
  */
 function generateExportStream(url, prefix, includeLayout) { // eslint-disable-line
-  if (utils.isLayout(url) && utils.getLayoutName(url) && (utils.getLayoutInstance(url) || isDefaultLayout(url)) || utils.isComponent(url) && utils.getComponentName(url) && (utils.getComponentInstance(url) || utils.isDefaultComponent(url))) {
+  if (utils.isLayout(url) && utils.getLayoutName(url) && (utils.getLayoutInstance(url) || utils.isDefaultLayout(url)) || utils.isComponent(url) && utils.getComponentName(url) && (utils.getComponentInstance(url) || utils.isDefaultComponent(url))) {
     // export single component or layout (default data or specific instance)
     return exportSingleItem(`${url}.json`);
   } else if (utils.getLayoutName(url) && !utils.getLayoutInstance(url) || utils.getComponentName(url) && !utils.getComponentInstance(url)) {

--- a/lib/cmd/export.js
+++ b/lib/cmd/export.js
@@ -12,6 +12,15 @@ const _ = require('lodash'),
 let layouts = []; // keep track of exported layouts, to dedupe the dispatches
 
 /**
+ * determine if a uri is a default layout uri
+ * @param  {string}  uri
+ * @return {Boolean}
+ */
+function isDefaultLayout(uri) {
+  return _.isString(uri) && !!uri.match(/\/_layouts\/[A-Za-z0-9\-]+$/);
+}
+
+/**
  * throw errors in the same place they can be dealt with
  * note: in the programmatic api, you need to handle errors yourself
  * because the stream will be pure data
@@ -37,12 +46,12 @@ function exportSingleItem(url) {
 }
 
 /**
- * export all instances of a component
+ * export all instances of a component or layout
  * @param  {string} url
  * @param  {string} prefix
  * @return {Stream} of dispatches (with prefix)
  */
-function exportComponentInstances(url, prefix) {
+function exportInstances(url, prefix) {
   return rest.get(url).map(toError).flatMap((res) => {
     return h(_.map(res, (uri) => exportSingleItem(`${prefixes.uriToUrl(prefix, uri)}.json`))).flatten();
   });
@@ -56,7 +65,19 @@ function exportComponentInstances(url, prefix) {
  */
 function exportAllComponents(url, prefix) {
   return rest.get(url).map(toError).flatMap((res) => {
-    return h(_.map(res, (name) => exportComponentInstances(`${prefix}/_components/${name}/instances`, prefix))).flatten();
+    return h(_.map(res, (name) => exportInstances(`${prefix}/_components/${name}/instances`, prefix))).flatten();
+  });
+}
+
+/**
+ * export all instances of all layouts
+ * @param  {string} url
+ * @param  {string} prefix
+ * @return {Stream} of dispatches (with prefix)
+ */
+function exportAllLayouts(url, prefix) {
+  return rest.get(url).map(toError).flatMap((res) => {
+    return h(_.map(res, (name) => exportInstances(`${prefix}/_layouts/${name}/instances`, prefix))).flatten();
   });
 }
 
@@ -153,15 +174,18 @@ function exportPublicURL(url, includeLayout) {
  * @return {Stream}
  */
 function generateExportStream(url, prefix, includeLayout) { // eslint-disable-line
-  if (utils.isComponent(url) && utils.getComponentName(url) && (utils.getComponentInstance(url) || utils.isDefaultComponent(url))) {
-    // export single component (default data or specific instance)
+  if (utils.isLayout(url) && utils.getLayoutName(url) && (utils.getLayoutInstance(url) || isDefaultLayout(url)) || utils.isComponent(url) && utils.getComponentName(url) && (utils.getComponentInstance(url) || utils.isDefaultComponent(url))) {
+    // export single component or layout (default data or specific instance)
     return exportSingleItem(`${url}.json`);
-  } else if (utils.getComponentName(url) && !utils.getComponentInstance(url)) {
-    // export all instances of a component
-    return exportComponentInstances(url, prefix);
+  } else if (utils.getLayoutName(url) && !utils.getLayoutInstance(url) || utils.getComponentName(url) && !utils.getComponentInstance(url)) {
+    // export all instances of a component or layout
+    return exportInstances(url, prefix);
   } else if (_.includes(url, '_components')) {
     // export all instances of all components
     return exportAllComponents(url, prefix);
+  } else if (_.includes(url, '_layouts')) {
+    // export all instances of all layouts
+    return exportAllLayouts(url, prefix);
   } else if (utils.isPage(url) && utils.getPageInstance(url)) {
     // export single page, including layout if it is enabled
     return exportSinglePage(url, prefix, includeLayout);

--- a/lib/cmd/export.test.js
+++ b/lib/cmd/export.test.js
@@ -68,7 +68,48 @@ describe('export', () => {
       });
     });
 
-    it('exports dispatch from page', () => {
+    it('exports dispatch from layout instance', () => {
+      fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
+      return lib.fromURL('http://domain.com/_layouts/foo', { concurrency }).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ '/_layouts/foo': { a: 'b' }}]);
+      });
+    });
+
+    it('exports dispatch from deep layout instance', () => {
+      fetch.mockResponseOnce(JSON.stringify({
+        a: 'b',
+        content: [{
+          _ref: 'domain.com/_components/bar',
+          c: 'd'
+        }]
+      }));
+      return lib.fromURL('http://domain.com/_layouts/foo', { concurrency }).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ '/_layouts/foo': { a: 'b', content: [{ _ref: '/_components/bar', c: 'd' }] }}]);
+      });
+    });
+
+    it('exports dispatch from all layout instances', () => {
+      fetch.mockResponseOnce(JSON.stringify(['domain.com/_layouts/foo/instances/1', 'domain.com/_layouts/foo/instances/2']));
+      fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
+      fetch.mockResponseOnce(JSON.stringify({ c: 'd' }));
+      return lib.fromURL('http://domain.com/_layouts/foo/instances', { concurrency }).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ '/_layouts/foo/instances/1': { a: 'b' } }, { '/_layouts/foo/instances/2': { c: 'd' } }]);
+      });
+    });
+
+    it('exports dispatch from all layouts', () => {
+      fetch.mockResponseOnce(JSON.stringify(['foo', 'bar']));
+      fetch.mockResponseOnce(JSON.stringify(['domain.com/_layouts/foo/instances/1', 'domain.com/_layouts/foo/instances/2']));
+      fetch.mockResponseOnce(JSON.stringify(['domain.com/_layouts/bar/instances/1']));
+      fetch.mockResponseOnce(JSON.stringify({ a: 'b' })); // foo 1
+      fetch.mockResponseOnce(JSON.stringify({ c: 'd' })); // foo 2
+      fetch.mockResponseOnce(JSON.stringify({ e: 'f' })); // bar 1
+      return lib.fromURL('http://domain.com/_layouts', { concurrency }).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ '/_layouts/foo/instances/1': { a: 'b' } }, { '/_layouts/foo/instances/2': { c: 'd' } }, { '/_layouts/bar/instances/1': { e: 'f' } }]);
+      });
+    });
+
+    it('exports dispatch from page (legacy)', () => {
       fetch.mockResponseOnce(JSON.stringify({
         layout: 'domain.com/_components/layout/instances/1',
         main: ['domain.com/_components/foo/instances/1']
@@ -79,7 +120,7 @@ describe('export', () => {
       });
     });
 
-    it('exports dispatch from page with layout', () => {
+    it('exports dispatch from page with layout (legacy)', () => {
       fetch.mockResponseOnce(JSON.stringify({
         layout: 'domain.com/_components/layout/instances/1',
         main: ['domain.com/_components/foo/instances/1']
@@ -96,7 +137,7 @@ describe('export', () => {
       });
     });
 
-    it('exports dispatch from all pages', () => {
+    it('exports dispatch from all pages (legacy)', () => {
       fetch.mockResponseOnce(JSON.stringify(['domain.com/_pages/foo', 'domain.com/_pages/bar']));
       fetch.mockResponseOnce(JSON.stringify({
         layout: 'domain.com/_components/layout/instances/1',
@@ -118,7 +159,7 @@ describe('export', () => {
       });
     });
 
-    it('exports dispatch from all pages with shared layout', () => {
+    it('exports dispatch from all pages with shared layout (legacy)', () => {
       fetch.mockResponseOnce(JSON.stringify(['domain.com/_pages/foo', 'domain.com/_pages/bar']));
       fetch.mockResponseOnce(JSON.stringify({
         layout: 'domain.com/_components/layout/instances/1',
@@ -137,6 +178,81 @@ describe('export', () => {
           { '/_components/foo/instances/1': { a: 'b' }},
           { '/_components/layout/instances/1': { main: 'main' }}, // only appears once
           { '/_pages/bar': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/2'] } },
+          { '/_components/foo/instances/2': { c: 'd' }}
+        ]);
+        lib.clearLayouts();
+      });
+    });
+
+    it('exports dispatch from page', () => {
+      fetch.mockResponseOnce(JSON.stringify({
+        layout: 'domain.com/_layouts/layout/instances/1',
+        main: ['domain.com/_components/foo/instances/1']
+      }));
+      fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
+      return lib.fromURL('http://domain.com/_pages/foo', { concurrency }).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([{ '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] }}, { '/_components/foo/instances/1': { a: 'b' }}]);
+      });
+    });
+
+    it('exports dispatch from page with layout', () => {
+      fetch.mockResponseOnce(JSON.stringify({
+        layout: 'domain.com/_layouts/layout/instances/1',
+        main: ['domain.com/_components/foo/instances/1']
+      }));
+      fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
+      fetch.mockResponseOnce(JSON.stringify({ main: 'main' }));
+      return lib.fromURL('http://domain.com/_pages/foo', { layout: true, concurrency }).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([
+          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] } },
+          { '/_components/foo/instances/1': { a: 'b' }},
+          { '/_layouts/layout/instances/1': { main: 'main' }}
+        ]);
+        lib.clearLayouts();
+      });
+    });
+
+    it('exports dispatch from all pages', () => {
+      fetch.mockResponseOnce(JSON.stringify(['domain.com/_pages/foo', 'domain.com/_pages/bar']));
+      fetch.mockResponseOnce(JSON.stringify({
+        layout: 'domain.com/_layouts/layout/instances/1',
+        main: ['domain.com/_components/foo/instances/1']
+      }));
+      fetch.mockResponseOnce(JSON.stringify({
+        layout: 'domain.com/_layouts/layout/instances/1',
+        main: ['domain.com/_components/foo/instances/2']
+      }));
+      fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
+      fetch.mockResponseOnce(JSON.stringify({ c: 'd' }));
+      return lib.fromURL('http://domain.com/_pages', { concurrency }).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([
+          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] } },
+          { '/_components/foo/instances/1': { a: 'b' }},
+          { '/_pages/bar': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/2'] } },
+          { '/_components/foo/instances/2': { c: 'd' }}
+        ]);
+      });
+    });
+
+    it('exports dispatch from all pages with shared layout', () => {
+      fetch.mockResponseOnce(JSON.stringify(['domain.com/_pages/foo', 'domain.com/_pages/bar']));
+      fetch.mockResponseOnce(JSON.stringify({
+        layout: 'domain.com/_layouts/layout/instances/1',
+        main: ['domain.com/_components/foo/instances/1']
+      }));
+      fetch.mockResponseOnce(JSON.stringify({
+        layout: 'domain.com/_layouts/layout/instances/1',
+        main: ['domain.com/_components/foo/instances/2']
+      }));
+      fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
+      fetch.mockResponseOnce(JSON.stringify({ main: 'main' }));
+      fetch.mockResponseOnce(JSON.stringify({ c: 'd' }));
+      return lib.fromURL('http://domain.com/_pages', { layout: true, concurrency }).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([
+          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] } },
+          { '/_components/foo/instances/1': { a: 'b' }},
+          { '/_layouts/layout/instances/1': { main: 'main' }}, // only appears once
+          { '/_pages/bar': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/2'] } },
           { '/_components/foo/instances/2': { c: 'd' }}
         ]);
         lib.clearLayouts();

--- a/lib/cmd/import.js
+++ b/lib/cmd/import.js
@@ -111,7 +111,8 @@ function importItems(str, url, options = {}) {
               '_pages:\n',
               '_users:\n',
               '_uris:\n',
-              '_lists:\n'
+              '_lists:\n',
+              '_layouts:\n'
             ];
 
             if (_.includes(rootProps, line)) {

--- a/lib/cmd/import.test.js
+++ b/lib/cmd/import.test.js
@@ -75,7 +75,13 @@ describe('import', () => {
 
   it('imports bootstrap', () => {
     fetch.mockResponseOnce('{}');
+    fetch.mockResponseOnce('{}');
     return lib(yaml.safeDump({
+      _layouts: {
+        abc: {
+          a: 'b'
+        }
+      },
       _components: {
         article: {
           instances: {
@@ -93,8 +99,8 @@ describe('import', () => {
           }
         }
       }
-    }), url, { yaml: true, key, concurrency }).toPromise(Promise).then((res) => {
-      expect(res).toEqual({ type: 'success', message: 'http://domain.com/_components/article/instances/foo' });
+    }), url, { yaml: true, key, concurrency }).collect().toPromise(Promise).then((res) => {
+      expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_layouts/abc' }, { type: 'success', message: 'http://domain.com/_components/article/instances/foo' }]);
     });
   });
 
@@ -136,6 +142,18 @@ describe('import', () => {
       '/_uris/foo': '/_pages/foo'
     }), url, { key }).collect().toPromise(Promise).then((res) => {
       expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_uris/ZG9tYWluLmNvbS9mb28=' }]);
+    });
+  });
+
+  it('imports layouts', () => {
+    fetch.mockResponseOnce('{}');
+    fetch.mockResponseOnce('{}');
+    return lib(JSON.stringify({
+      '/_layouts/foo': {
+        head: [{ _ref: '/_components/foo' }]
+      }
+    }), url, { key }).collect().toPromise(Promise).then((res) => {
+      expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_layouts/foo' }]);
     });
   });
 });

--- a/lib/cmd/lint.js
+++ b/lib/cmd/lint.js
@@ -77,7 +77,7 @@ function pushRestError(err, push) {
 }
 
 /**
- * recursively check all references in a component
+ * recursively check all references in a component or layout
  * @param  {*} url
  * @param {string} prefix
  * @param  {number} concurrency
@@ -241,7 +241,7 @@ function lintUrl(rawUrl, options = {}) {
     return h.of({ type: 'error', message: 'URL is not defined! Please specify a url to lint' });
   }
 
-  if (utils.isComponent(url)) {
+  if (utils.isComponent(url) || utils.isLayout(url)) {
     return checkComponent(url, prefixes.getFromUrl(url), concurrency);
   } else if (utils.isPage(url)) {
     return checkPage(url, prefixes.getFromUrl(url), concurrency);

--- a/lib/cmd/lint.test.js
+++ b/lib/cmd/lint.test.js
@@ -22,6 +22,14 @@ describe('lint', () => {
       });
     });
 
+    // note: layout tests are basically the same as component tests, so only include this one
+    it('lints an existing layout without children', () => {
+      fetch.mockResponseOnce('{}');
+      return lib.lintUrl('domain.com/_layouts/foo/instances/bar', {concurrency}).toPromise(Promise).then((res) => {
+        expect(res).toEqual({ type: 'success', message: 'http://domain.com/_layouts/foo/instances/bar' });
+      });
+    });
+
     it('lints an existing component without children', () => {
       fetch.mockResponseOnce('{}');
       return lib.lintUrl('domain.com/_components/foo/instances/bar', {concurrency}).toPromise(Promise).then((res) => {

--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -92,7 +92,18 @@ function parseLayoutBootstrap(dispatches, layouts, { bootstrap, added }) {
       _.forOwn(data.instances, (instanceData, instance) => {
         const instanceURI = `/_layouts/${name}/instances/${instance}`;
 
+        let meta;
+
+        // parse out metadata
+        if (instanceData.meta) {
+          meta = instanceData.meta;
+          delete instanceData.meta;
+        }
+
         dispatches.push({ [instanceURI]: composer.denormalize(instanceData, bootstrap, added) });
+        if (meta) {
+          dispatches.push({ [`${instanceURI}/meta`]: meta });
+        }
       });
     }
 
@@ -109,6 +120,8 @@ function parseLayoutBootstrap(dispatches, layouts, { bootstrap, added }) {
  */
 function parsePageBootstrap(dispatches, pages) {
   return _.reduce(pages, (dispatches, page, id) => {
+    let meta;
+
     if (id[0] === '/') {
       // if a page starts with a slash, remove it so we can generate the uri
       id = id.slice(1);
@@ -120,7 +133,17 @@ function parsePageBootstrap(dispatches, pages) {
       delete page.url; // don't pass this through
     }
 
+    // parse out metadata
+    if (page.meta) {
+      meta = page.meta;
+      delete page.meta;
+    }
+
     dispatches.push({ [`/_pages/${id}`]: page });
+    // add meta dispatch _after_ page data
+    if (meta) {
+      dispatches.push({ [`/_pages/${id}/meta`]: meta });
+    }
     return dispatches;
   }, dispatches);
 }
@@ -227,7 +250,14 @@ function parseLayoutDispatch(uri, dispatch, bootstrap) {
     instance = utils.getLayoutInstance(uri),
     path = instance ? `_layouts['${name}'].instances['${instance}']` : `_layouts['${name}']`;
 
-  _.set(bootstrap, path, composer.normalize(deepData));
+  if (utils.isLayoutMeta(uri)) {
+    // if we're just setting metadata, return early
+    // note: only instances can have metadata
+    _.set(bootstrap, `_layouts['${name}'].instances['${instance}'].meta`, deepData);
+    return bootstrap;
+  }
+
+  _.set(bootstrap, path, _.assign({}, _.get(bootstrap, path, {}), composer.normalize(deepData)));
 
   return deepReduce(bootstrap, deepData, (ref, val) => {
     // reduce on the child components and their instances
@@ -250,13 +280,19 @@ function parsePageDispatch(uri, dispatch, bootstrap) {
   let id = utils.getPageInstance(uri),
     page = dispatch[uri];
 
+  if (utils.isPageMeta(uri)) {
+    // if we're just setting metadata, return early
+    _.set(bootstrap, `_pages['${id}'].meta`, page);
+    return bootstrap;
+  }
+
   // unpublished pages should not have 'url', but rather 'customUrl'
   if (page.url && !page.customUrl) {
     page.customUrl = page.url;
     delete page.url; // don't pass this through
   }
 
-  _.set(bootstrap, `_pages['${id}']`, page);
+  _.set(bootstrap, `_pages['${id}']`, _.assign({}, _.get(bootstrap, `_pages['${id}']`, {}), page));
   return bootstrap;
 }
 

--- a/lib/formatting.js
+++ b/lib/formatting.js
@@ -70,6 +70,37 @@ function parseComponentBootstrap(dispatches, components, { bootstrap, added }) {
 }
 
 /**
+ * create dispatches from layout defaults and instances
+ * @param  {array} dispatches e.g. [{ unprefixed ref: composed data }]
+ * @param  {object} layouts
+ * @param  {object} bootstrap obj to refer to
+ * @param {object} added
+ * @return {array} of dispatches
+ */
+function parseLayoutBootstrap(dispatches, layouts, { bootstrap, added }) {
+  return _.reduce(layouts, (dispatches, data, name) => {
+    const defaultData = _.omit(data, 'instances'),
+      defaultURI = `/_layouts/${name}`;
+
+    // first, compose and add the default data if it hasn't already been added
+    if (_.size(defaultData)) {
+      dispatches.push({ [defaultURI]: composer.denormalize(defaultData, bootstrap, added) });
+    }
+
+    // second, compose and add instances if they haven't already been added
+    if (data.instances && _.size(data.instances)) {
+      _.forOwn(data.instances, (instanceData, instance) => {
+        const instanceURI = `/_layouts/${name}/instances/${instance}`;
+
+        dispatches.push({ [instanceURI]: composer.denormalize(instanceData, bootstrap, added) });
+      });
+    }
+
+    return dispatches;
+  }, dispatches);
+}
+
+/**
  * create dispatches from page data
  * note: these pages are not composed
  * @param  {array} dispatches
@@ -140,6 +171,7 @@ function parseBootstrap(bootstrap) {
     dispatches = _.reduce(bootstrap, (dispatches, items, type) => {
       switch (type) {
         case '_components': return parseComponentBootstrap(dispatches, items, { bootstrap, added });
+        case '_layouts': return parseLayoutBootstrap(dispatches, items, { bootstrap, added });
         case '_pages': return parsePageBootstrap(dispatches, items);
         case '_users': return parseUsersBootstrap(dispatches, items);
         default: return parseArbitraryBootstrapData(dispatches, items, type); // uris, lists
@@ -179,6 +211,31 @@ function parseComponentDispatch(uri, dispatch, bootstrap) {
       deepPath = deepInstance ? `_components['${deepName}'].instances['${deepInstance}']` : `_components['${deepName}']`;
 
     _.set(bootstrap, deepPath, composer.normalize(val));
+  });
+}
+
+/**
+ * add deep layout data to a bootstrap
+ * @param {string} uri
+ * @param  {object} dispatch
+ * @param  {object} bootstrap
+ * @return {object}
+ */
+function parseLayoutDispatch(uri, dispatch, bootstrap) {
+  const deepData = dispatch[uri],
+    name = utils.getLayoutName(uri),
+    instance = utils.getLayoutInstance(uri),
+    path = instance ? `_layouts['${name}'].instances['${instance}']` : `_layouts['${name}']`;
+
+  _.set(bootstrap, path, composer.normalize(deepData));
+
+  return deepReduce(bootstrap, deepData, (ref, val) => {
+    // reduce on the child components and their instances
+    const deepName = utils.getComponentName(ref),
+      deepInstance = utils.getComponentInstance(ref),
+      deepPath = deepInstance ? `_components['${deepName}'].instances['${deepInstance}']` : `_components['${deepName}']`;
+
+    _.set(bootstrap, deepPath, _.assign({}, _.get(bootstrap, deepPath, {}), composer.normalize(val)));
   });
 }
 
@@ -252,6 +309,7 @@ function generateBootstrap(bootstrap, dispatch) {
 
   switch (type) {
     case '/_components': return parseComponentDispatch(uri, dispatch, bootstrap);
+    case '/_layouts': return parseLayoutDispatch(uri, dispatch, bootstrap);
     case '/_pages': return parsePageDispatch(uri, dispatch, bootstrap);
     case '/_users': return parseUsersDispatch(uri, dispatch, bootstrap);
     default: return parseArbitraryDispatchData(uri, dispatch, bootstrap); // uris, lists

--- a/lib/formatting.test.js
+++ b/lib/formatting.test.js
@@ -44,7 +44,8 @@ describe('formatting', () => {
               head: [{
                 _ref: '/_components/meta-title/instances/bar'
               }],
-              main: 'main'
+              main: 'main',
+              meta: { title: 'Lorem Ipsum Layout' }
             }
           }
         },
@@ -54,6 +55,13 @@ describe('formatting', () => {
           }],
           main: 'main'
         },
+        tags: {
+          instances: {
+            first: {
+              main: 'main'
+            }
+          }
+        }
       },
       _components: {
         'meta-title': {
@@ -70,7 +78,8 @@ describe('formatting', () => {
       _pages: {
         foo: {
           layout: '/_components/layout/instances/bar',
-          main: ['/_components/foo/instances/bar']
+          main: ['/_components/foo/instances/bar'],
+          meta: { title: 'Foo' }
         },
         '/bar': { // it deals with slahes
           layout: '/_components/layout/instances/bar',
@@ -137,11 +146,17 @@ describe('formatting', () => {
         main: 'main'
       }
     }, {
+      '/_layouts/index/instances/foo/meta': { title: 'Lorem Ipsum Layout' }
+    }, {
       '/_layouts/article': {
         head: [{
           _ref: '/_components/meta-title',
           text: 'empty'
         }],
+        main: 'main'
+      }
+    }, {
+      '/_layouts/tags/instances/first': {
         main: 'main'
       }
     }];
@@ -150,6 +165,8 @@ describe('formatting', () => {
         layout: '/_components/layout/instances/bar',
         main: ['/_components/foo/instances/bar']
       }
+    }, {
+      '/_pages/foo/meta': { title: 'Foo' }
     }, {
       '/_pages/bar': {
         layout: '/_components/layout/instances/bar',
@@ -275,12 +292,15 @@ describe('formatting', () => {
           main: ['/_components/foo/instances/bar'],
           url: 'http://google.com'
         }
+      }, {
+        '/_pages/foo/meta': { title: 'Foo' }
       }])).toPromise(Promise).then((res) => {
         expect(res).toEqual({
           _pages: {
             foo: { // adds slash
               layout: '/_layouts/layout/instances/bar',
-              main: ['/_components/foo/instances/bar']
+              main: ['/_components/foo/instances/bar'],
+              meta: { title: 'Foo' }
             },
             bar: {
               layout: '/_layouts/layout/instances/bar',
@@ -320,6 +340,8 @@ describe('formatting', () => {
       }, {
         '/_layouts/l/instances/i': { head: 'head' }
       }, {
+        '/_layouts/l/instances/i/meta': { title: 'L'}
+      }, {
         '/_users/abc': { username: 'a', provider: 'b', auth: 'admin' }
       }, {
         '/_users/def': { username: 'd', provider: 'e', auth: 'admin' }
@@ -333,7 +355,8 @@ describe('formatting', () => {
             l: {
               instances: {
                 i: {
-                  head: 'head'
+                  head: 'head',
+                  meta: { title: 'L' }
                 }
               }
             }

--- a/lib/formatting.test.js
+++ b/lib/formatting.test.js
@@ -3,8 +3,8 @@ const h = require('highland'),
   lib = require('./formatting');
 
 describe('formatting', () => {
-  let bootstrapComponents, bootstrapPages, bootstrapUsers, bootstrapUserError, bootstrapArbitrary,
-    componentDispatch, pageDispatch, userDispatch, arbitraryDispatch;
+  let bootstrapComponents, bootstrapLayouts, bootstrapPages, bootstrapUsers, bootstrapUserError, bootstrapArbitrary,
+    componentDispatch, layoutDispatch, pageDispatch, userDispatch, arbitraryDispatch;
 
   beforeEach(() => {
     bootstrapComponents = {
@@ -33,6 +33,36 @@ describe('formatting', () => {
         },
         image: {
           url: 'domain.com/image'
+        }
+      }
+    };
+    bootstrapLayouts = {
+      _layouts: {
+        index: {
+          instances: {
+            foo: {
+              head: [{
+                _ref: '/_components/meta-title/instances/bar'
+              }],
+              main: 'main'
+            }
+          }
+        },
+        article: {
+          head: [{
+            _ref: '/_components/meta-title'
+          }],
+          main: 'main'
+        },
+      },
+      _components: {
+        'meta-title': {
+          text: 'empty',
+          instances: {
+            bar: {
+              text: 'lorem ipsum'
+            }
+          }
         }
       }
     };
@@ -98,6 +128,23 @@ describe('formatting', () => {
         url: 'domain.com/image'
       }
     }];
+    layoutDispatch = [{
+      '/_layouts/index/instances/foo': {
+        head: [{
+          _ref: '/_components/meta-title/instances/bar',
+          text: 'lorem ipsum'
+        }],
+        main: 'main'
+      }
+    }, {
+      '/_layouts/article': {
+        head: [{
+          _ref: '/_components/meta-title',
+          text: 'empty'
+        }],
+        main: 'main'
+      }
+    }];
     pageDispatch = [{
       '/_pages/foo': {
         layout: '/_components/layout/instances/bar',
@@ -132,7 +179,7 @@ describe('formatting', () => {
 
   describe('toDispatch', () => {
     it('passes through empty root properties', () => {
-      return lib.toDispatch(h([{ _components: {}, _pages: {}, _uris: {}, _users: [] }])).collect().toPromise(Promise).then((res) => {
+      return lib.toDispatch(h([{ _components: {}, _layouts: {}, _pages: {}, _uris: {}, _users: [] }])).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([]);
       });
     });
@@ -140,6 +187,12 @@ describe('formatting', () => {
     it('converts bootstrapped components to dispatch', () => {
       return lib.toDispatch(h([bootstrapComponents])).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual(componentDispatch);
+      });
+    });
+
+    it('converts bootstrapped layouts to dispatch', () => {
+      return lib.toDispatch(h([bootstrapLayouts])).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual(layoutDispatch);
       });
     });
 
@@ -175,7 +228,13 @@ describe('formatting', () => {
       });
     });
 
-    it('converts page dispatch to bootstrap', () => {
+    it('converts deep layout dispatch to bootstrap', () => {
+      return lib.toBootstrap(h(layoutDispatch)).toPromise(Promise).then((res) => {
+        expect(res).toEqual(bootstrapLayouts);
+      });
+    });
+
+    it('converts page dispatch to bootstrap (legacy)', () => {
       return lib.toBootstrap(h([{
         '/_pages/foo': { // convert slash
           layout: '/_components/layout/instances/bar',
@@ -196,6 +255,35 @@ describe('formatting', () => {
             },
             bar: {
               layout: '/_components/layout/instances/bar',
+              main: ['/_components/foo/instances/bar'],
+              customUrl: 'http://google.com' // deals with url
+            }
+          }
+        });
+      });
+    });
+
+    it('converts page dispatch to bootstrap', () => {
+      return lib.toBootstrap(h([{
+        '/_pages/foo': { // convert slash
+          layout: '/_layouts/layout/instances/bar',
+          main: ['/_components/foo/instances/bar']
+        }
+      }, {
+        '/_pages/bar': {
+          layout: '/_layouts/layout/instances/bar',
+          main: ['/_components/foo/instances/bar'],
+          url: 'http://google.com'
+        }
+      }])).toPromise(Promise).then((res) => {
+        expect(res).toEqual({
+          _pages: {
+            foo: { // adds slash
+              layout: '/_layouts/layout/instances/bar',
+              main: ['/_components/foo/instances/bar']
+            },
+            bar: {
+              layout: '/_layouts/layout/instances/bar',
               main: ['/_components/foo/instances/bar'],
               customUrl: 'http://google.com' // deals with url
             }
@@ -230,6 +318,8 @@ describe('formatting', () => {
       return lib.toBootstrap(h([{
         '/_components/a': { child: { _ref: '/_components/b', a: 'b' } }
       }, {
+        '/_layouts/l/instances/i': { head: 'head' }
+      }, {
         '/_users/abc': { username: 'a', provider: 'b', auth: 'admin' }
       }, {
         '/_users/def': { username: 'd', provider: 'e', auth: 'admin' }
@@ -238,6 +328,15 @@ describe('formatting', () => {
           _components: {
             a: { child: { _ref: '/_components/b' } },
             b: { a: 'b' }
+          },
+          _layouts: {
+            l: {
+              instances: {
+                i: {
+                  head: 'head'
+                }
+              }
+            }
           },
           _users: [{
             username: 'a',

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -22,7 +22,7 @@ function add(dispatch, prefix) {
     prefix = urlToUri(prefix);
   }
 
-  return h(replace(stringDispatch, /"\/_?(components|uris|pages|lists|users)(\/[\w-\/]*)/g, (match, type, name) => {
+  return h(replace(stringDispatch, /"\/_?(components|uris|pages|lists|users|layouts)(\/[\w-\/]*)/g, (match, type, name) => {
     if (type === 'uris') {
       return Promise.resolve(`"${prefix}/_${type}/${b64.encode(prefix + name)}`);
     } else {
@@ -47,7 +47,7 @@ function remove(dispatch, prefix) {
     prefix = urlToUri(prefix);
   }
 
-  return h(replace(stringDispatch, new RegExp(`"${prefix}\/_?(components|uris|pages|lists|users)/(.+?)"`, 'g'), (match, type, end) => {
+  return h(replace(stringDispatch, new RegExp(`"${prefix}\/_?(components|uris|pages|lists|users|layouts)/(.+?)"`, 'g'), (match, type, end) => {
     if (type === 'uris') {
       return Promise.resolve(`"/_${type}${b64.decode(end).replace(prefix, '')}"`);
     } else {

--- a/lib/prefixes.test.js
+++ b/lib/prefixes.test.js
@@ -64,6 +64,16 @@ describe('prefixes', () => {
       });
     });
 
+    it('adds prefix to layouts', () => {
+      return lib.add({
+        '/_layouts/foo/instances/bar': { a: 'b' }
+      }, prefix).toPromise(Promise).then((res) => {
+        expect(res).toEqual({
+          'domain.com/_layouts/foo/instances/bar': { a: 'b' }
+        });
+      });
+    });
+
     it('adds prefix to customUrl', () => {
       return lib.add({
         '/_pages/abc': { customUrl: '/' }
@@ -156,6 +166,16 @@ describe('prefixes', () => {
       });
     });
 
+    it('removes prefix from layouts', () => {
+      return lib.remove({
+        'domain.com/_layouts/foo/instances/bar': { a: 'b' }
+      }, prefix).toPromise(Promise).then((res) => {
+        expect(res).toEqual({
+          '/_layouts/foo/instances/bar': { a: 'b' }
+        });
+      });
+    });
+
     it('removes prefix from customUrl', () => {
       return lib.remove({
         'domain.com/_pages/abc': { customUrl: 'http://domain.com/' }
@@ -202,6 +222,11 @@ describe('prefixes', () => {
       expect(lib.getFromUrl('domain.com/somepath/_pages/foo')).toBe('domain.com/somepath');
     });
 
+    it('gets prefix for layouts', () => {
+      expect(lib.getFromUrl('domain.com/_layouts/foo')).toBe('domain.com');
+      expect(lib.getFromUrl('domain.com/somepath/_layouts/foo')).toBe('domain.com/somepath');
+    });
+
     it('gets prefix for users', () => {
       expect(lib.getFromUrl('domain.com/_users/foo')).toBe('domain.com');
       expect(lib.getFromUrl('domain.com/somepath/_users/foo')).toBe('domain.com/somepath');
@@ -222,11 +247,27 @@ describe('prefixes', () => {
     it('converts component uri', () => {
       expect(lib.uriToUrl('http://domain.com', 'domain.com/_components/foo/instances/bar')).toBe('http://domain.com/_components/foo/instances/bar');
     });
+
+    it('converts page uri', () => {
+      expect(lib.uriToUrl('http://domain.com', 'domain.com/_pages/foo')).toBe('http://domain.com/_pages/foo');
+    });
+
+    it('converts layout uri', () => {
+      expect(lib.uriToUrl('http://domain.com', 'domain.com/_layouts/foo/instances/bar')).toBe('http://domain.com/_layouts/foo/instances/bar');
+    });
   });
 
   describe('urlToUri', () => {
     it('converts component uri', () => {
       expect(lib.urlToUri('http://domain.com/_components/foo/instances/bar')).toBe('domain.com/_components/foo/instances/bar');
+    });
+
+    it('converts page uri', () => {
+      expect(lib.urlToUri('http://domain.com/_pages/foo/instances/bar')).toBe('domain.com/_pages/foo/instances/bar');
+    });
+
+    it('converts layout uri', () => {
+      expect(lib.urlToUri('http://domain.com/_layouts/foo/instances/bar')).toBe('domain.com/_layouts/foo/instances/bar');
     });
 
     it('converts bare domain', () => {

--- a/lib/types.js
+++ b/lib/types.js
@@ -2,6 +2,7 @@
 
 // all types of data
 module.exports = [
+  '/_layouts',
   '/_components',
   '/_pages',
   '/_users',

--- a/package-lock.json
+++ b/package-lock.json
@@ -760,9 +760,9 @@
       }
     },
     "clayutils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/clayutils/-/clayutils-2.4.0.tgz",
-      "integrity": "sha512-vsWEZbas4W0lfYITqNByLtvU6YOBjEivnzosRiv99rRzBVEn8msDksNjnF+7IWfDhdJzsNGFjROXxJkPKbN/5A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/clayutils/-/clayutils-2.5.0.tgz",
+      "integrity": "sha512-YH7RaqLvXrVvNYiUswIrvT1MVXlN0rFVqIMlXdTtUia1uK+JiVQL+dA2SP4y5nK7IsY1HfCWf6qeopJvbhBzWg==",
       "requires": {
         "glob": "7.1.2",
         "lodash": "4.17.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -760,9 +760,9 @@
       }
     },
     "clayutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/clayutils/-/clayutils-2.0.3.tgz",
-      "integrity": "sha512-6oEhoGLV3UHwdXbybf/+R5wIffn36YSdHvKEvouZmm37VMaLEjI6aOWND/nTfsF3m5qAxUxTmJl1zrYnWoBGAg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/clayutils/-/clayutils-2.4.0.tgz",
+      "integrity": "sha512-vsWEZbas4W0lfYITqNByLtvU6YOBjEivnzosRiv99rRzBVEn8msDksNjnF+7IWfDhdJzsNGFjROXxJkPKbN/5A==",
       "requires": {
         "glob": "7.1.2",
         "lodash": "4.17.5",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "base-64": "^0.1.0",
     "chalk": "^2.3.2",
     "clay-log": "^1.3.0",
-    "clayutils": "^2.4.0",
+    "clayutils": "^2.5.0",
     "get-stdin": "^5.0.1",
     "highland": "^3.0.0-beta.5",
     "home-config": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "base-64": "^0.1.0",
     "chalk": "^2.3.2",
     "clay-log": "^1.3.0",
-    "clayutils": "^2.0.3",
+    "clayutils": "^2.4.0",
     "get-stdin": "^5.0.1",
     "highland": "^3.0.0-beta.5",
     "home-config": "^0.1.0",


### PR DESCRIPTION
* FEATURE: handle `_layouts` in bootstraps and dispatches; importing, linting, and exporting
* FEATURE: handle `meta` in page data and layout instance data, in bootstraps and dispatches

Not sure if this should be considered a breaking change or not, as it does make `meta` a reserved word in page/layout data (currently you can use `meta` as the name of a page area / layout component list if you want, but I don't think any Clay installs actually do)