### PR TITLE
fix #74, more programmatic api goodness

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,33 @@ clay export domain.com/2017/02/some-slug.html # export published page via public
 clay export domnain.com/_lists/new-pages # export built-in 'New Page Templates' list (page uris will be unprefixed)
 ```
 
+# Programmatic API
+
+The core `claycli` functionality is exposed as an api, allowing you to use it in Node.js.
+
+**Config**
+
+* `config.get(type, alias)` - get `key` or `url` from config
+* `config.getAll()` - get full config object
+* `config.set(type, alias, value)` - set `key` or `url` in config
+
+**Lint**
+
+* `lint.lintUrl(url, { concurrency })` - lint a url
+* `lint.lintSchema(yaml)` - lint a schema (passed in as a string of yaml)
+
+**Import**
+
+* `import(string, url, { key, concurrency, publish, yaml })` - import a string of dispatches or bootstraps to the specified (site prefix) url
+* `import.parseBootstrap(string, url)` - parse a string of bootstrap data into a stream of prefixed dispatches. note: does NOT do http calls
+* `import.parseDispatch(string, url)` - parse a string of dispatches into a stream of prefixed dispatches. note: does NOT do http calls
+
+**Export**
+
+* `export.fromURL(url, { concurrency, layout, yaml })` - export a single url, e.g. `domain.com/_components/foo` or `domain.com/_pages`
+* `export.fromQuery(url, query, { key, concurrency, layout, yaml, size })` - export the results of a query (passed in as a string of yaml)
+* `export.clearLayouts()` - clear the layouts cache. when exporting pages with layouts, they'll be cached so they don't need to be exported for every page
+
 # Contributing
 
 Pull requests and stars are always welcome. For bugs and feature requests, [please create an issue](https://github.com/clay/claycli/issues/new).

--- a/lib/cmd/import.js
+++ b/lib/cmd/import.js
@@ -168,4 +168,41 @@ function importItems(str, url, options = {}) {
   }
 }
 
+/**
+ * parse string of bootstraps,
+ * returning a stream of prefixed dispatches
+ * @param  {string} str bootstrap
+ * @param  {string} url
+ * @return {Stream}
+ */
+function parseBootstrap(str, url) {
+  const prefix = config.get('url', url);
+
+  return h.of(str)
+    .map(yaml.safeLoad)
+    .errors((e, push) => push(new Error(`YAML syntax error: ${e.message.slice(0, e.message.indexOf(':'))}`)))
+    .flatMap((obj) => formatting.toDispatch(h.of(obj)))
+    .flatMap((dispatch) => prefixes.add(dispatch, prefix));
+}
+
+/**
+ * parse string of dispatches,
+ * returning a string of prefixed dispatches
+ * @param  {string} str
+ * @param  {string} url
+ * @return {Stream}
+ */
+function parseDispatch(str, url) {
+  const prefix = config.get('url', url);
+
+  return h.of(str)
+    .split()
+    .compact()
+    .map(JSON.parse)
+    .errors((e, push) => push(new Error(`JSON parser error: ${e.message}`)))
+    .flatMap((dispatch) => prefixes.add(dispatch, prefix));
+}
+
 module.exports = importItems;
+module.exports.parseBootstrap = parseBootstrap;
+module.exports.parseDispatch = parseDispatch;

--- a/lib/cmd/import.test.js
+++ b/lib/cmd/import.test.js
@@ -171,6 +171,22 @@ describe('import', () => {
         expect(res).toEqual([ { 'domain.com/_components/a': { b: 'c' } } ]);
       });
     });
+
+    it('parses single bootstrap with child components into dispatch, adding prefixes', () => {
+      return fn(yaml.safeDump({
+        _components: {
+          a: {
+            a: 'b',
+            children: [{ _ref: '/_components/b' }]
+          },
+          b: {
+            c: 'd'
+          }
+        }
+      }), url).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([ { 'domain.com/_components/a': { a: 'b', children: [{ _ref: 'domain.com/_components/b', c: 'd' }] } } ]);
+      });
+    });
   });
 
   describe('parseDispatch', () => {
@@ -191,6 +207,12 @@ describe('import', () => {
     it('adds prefixes to multiple dispatches', () => {
       return fn(JSON.stringify({ '/_components/a': { b: 'c' } }) + '\n' + JSON.stringify({ '/_components/b': { c: 'd' } }), url).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([ { 'domain.com/_components/a': { b: 'c' } }, { 'domain.com/_components/b': { c: 'd' } } ]);
+      });
+    });
+
+    it('adds prefixes to dispatches with children', () => {
+      return fn(JSON.stringify({ '/_components/a': { a: 'b', children: [{ _ref: '/_components/b', c: 'd' }] } }), url).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([ { 'domain.com/_components/a': { a: 'b', children: [{ _ref: 'domain.com/_components/b', c: 'd' }] } } ]);
       });
     });
   });

--- a/lib/cmd/import.test.js
+++ b/lib/cmd/import.test.js
@@ -156,4 +156,42 @@ describe('import', () => {
       expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_layouts/foo' }]);
     });
   });
+
+  describe('parseBootstrap', () => {
+    const fn = lib.parseBootstrap;
+
+    it('returns error if bad YAML', () => {
+      return fn(yaml.safeDump({ a: 'hi' }) + 'a', url).toPromise(Promise).catch((e) => {
+        expect(e.message).toBe('YAML syntax error: can not read a block mapping entry; a multiline key may not be an implicit key at line 3, column 1');
+      });
+    });
+
+    it('parses single bootstrap into dispatch, adding prefixes', () => {
+      return fn(yaml.safeDump({ _components: { a: { b: 'c' }} }), url).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([ { 'domain.com/_components/a': { b: 'c' } } ]);
+      });
+    });
+  });
+
+  describe('parseDispatch', () => {
+    const fn = lib.parseDispatch;
+
+    it('returns error if bad json', () => {
+      return fn(JSON.stringify({ a: 'hi' }) + 'a', url).toPromise(Promise).catch((e) => {
+        expect(e.message).toBe('JSON parser error: Unexpected token a in JSON at position 10');
+      });
+    });
+
+    it('adds prefixes to a single dispatch', () => {
+      return fn(JSON.stringify({ '/_components/a': { b: 'c' } }), url).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([ { 'domain.com/_components/a': { b: 'c' } } ]);
+      });
+    });
+
+    it('adds prefixes to multiple dispatches', () => {
+      return fn(JSON.stringify({ '/_components/a': { b: 'c' } }) + '\n' + JSON.stringify({ '/_components/b': { c: 'd' } }), url).collect().toPromise(Promise).then((res) => {
+        expect(res).toEqual([ { 'domain.com/_components/a': { b: 'c' } }, { 'domain.com/_components/b': { c: 'd' } } ]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
* add `import.parseBootstrap`, to parse bootstraps without doing http calls
* add `import.parseDispatch`, to parse dispatches without doing http calls
* add docs for all available programmatic methods

NOTE: `parseBootstrap` and `parseDispatch` both return streams of _prefixed_ dispatches, e.g.

```
{ 'domain.com/_components/a: { b: 'c' } }
```

These can easily be used by services that have their own connections to your Clay database.

If your bootstrap / dispatch contains errors, they'll be passed through the stream correctly _as errors_. Make sure you [watch for errors](http://highlandjs.org/#errors) or [otherwise handle them](http://highlandjs.org/#stopOnError).