### PR TITLE
When exporting, put pages after components and layouts

### DIFF
--- a/lib/cmd/export.js
+++ b/lib/cmd/export.js
@@ -90,7 +90,10 @@ function exportSinglePage(url, prefix, includeLayout) {
       layouts.push(res.layout); // keep track of it so we don't need to fetch it again
     }
 
-    return h([h.of({ [prefixes.urlToUri(url)]: res }), _.map(children, (uri) => exportSingleItem(`${prefixes.uriToUrl(prefix, uri)}.json`))]).flatten();
+    return h([
+      _.map(children, (uri) => exportSingleItem(`${prefixes.uriToUrl(prefix, uri)}.json`)),
+      h.of({ [prefixes.urlToUri(url)]: res })
+    ]).flatten();
   });
 }
 

--- a/lib/cmd/export.test.js
+++ b/lib/cmd/export.test.js
@@ -116,7 +116,10 @@ describe('export', () => {
       }));
       fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
       return lib.fromURL('http://domain.com/_pages/foo', { concurrency }).collect().toPromise(Promise).then((res) => {
-        expect(res).toEqual([{ '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] }}, { '/_components/foo/instances/1': { a: 'b' }}]);
+        expect(res).toEqual([
+          { '/_components/foo/instances/1': { a: 'b' }},
+          { '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] }}
+        ]);
       });
     });
 
@@ -129,9 +132,9 @@ describe('export', () => {
       fetch.mockResponseOnce(JSON.stringify({ main: 'main' }));
       return lib.fromURL('http://domain.com/_pages/foo', { layout: true, concurrency }).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([
-          { '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] } },
           { '/_components/foo/instances/1': { a: 'b' }},
-          { '/_components/layout/instances/1': { main: 'main' }}
+          { '/_components/layout/instances/1': { main: 'main' }},
+          { '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] } }
         ]);
         lib.clearLayouts();
       });
@@ -151,10 +154,10 @@ describe('export', () => {
       fetch.mockResponseOnce(JSON.stringify({ c: 'd' }));
       return lib.fromURL('http://domain.com/_pages', { concurrency }).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([
-          { '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] } },
           { '/_components/foo/instances/1': { a: 'b' }},
-          { '/_pages/bar': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/2'] } },
-          { '/_components/foo/instances/2': { c: 'd' }}
+          { '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] } },
+          { '/_components/foo/instances/2': { c: 'd' }},
+          { '/_pages/bar': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/2'] } }
         ]);
       });
     });
@@ -174,11 +177,11 @@ describe('export', () => {
       fetch.mockResponseOnce(JSON.stringify({ c: 'd' }));
       return lib.fromURL('http://domain.com/_pages', { layout: true, concurrency }).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([
-          { '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] } },
           { '/_components/foo/instances/1': { a: 'b' }},
           { '/_components/layout/instances/1': { main: 'main' }}, // only appears once
-          { '/_pages/bar': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/2'] } },
-          { '/_components/foo/instances/2': { c: 'd' }}
+          { '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] } },
+          { '/_components/foo/instances/2': { c: 'd' }},
+          { '/_pages/bar': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/2'] } }
         ]);
         lib.clearLayouts();
       });
@@ -191,7 +194,10 @@ describe('export', () => {
       }));
       fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
       return lib.fromURL('http://domain.com/_pages/foo', { concurrency }).collect().toPromise(Promise).then((res) => {
-        expect(res).toEqual([{ '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] }}, { '/_components/foo/instances/1': { a: 'b' }}]);
+        expect(res).toEqual([
+          { '/_components/foo/instances/1': { a: 'b' }},
+          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] }}
+        ]);
       });
     });
 
@@ -204,9 +210,9 @@ describe('export', () => {
       fetch.mockResponseOnce(JSON.stringify({ main: 'main' }));
       return lib.fromURL('http://domain.com/_pages/foo', { layout: true, concurrency }).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([
-          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] } },
           { '/_components/foo/instances/1': { a: 'b' }},
-          { '/_layouts/layout/instances/1': { main: 'main' }}
+          { '/_layouts/layout/instances/1': { main: 'main' }},
+          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] } }
         ]);
         lib.clearLayouts();
       });
@@ -226,10 +232,10 @@ describe('export', () => {
       fetch.mockResponseOnce(JSON.stringify({ c: 'd' }));
       return lib.fromURL('http://domain.com/_pages', { concurrency }).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([
-          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] } },
           { '/_components/foo/instances/1': { a: 'b' }},
-          { '/_pages/bar': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/2'] } },
-          { '/_components/foo/instances/2': { c: 'd' }}
+          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] } },
+          { '/_components/foo/instances/2': { c: 'd' }},
+          { '/_pages/bar': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/2'] } }
         ]);
       });
     });
@@ -249,11 +255,11 @@ describe('export', () => {
       fetch.mockResponseOnce(JSON.stringify({ c: 'd' }));
       return lib.fromURL('http://domain.com/_pages', { layout: true, concurrency }).collect().toPromise(Promise).then((res) => {
         expect(res).toEqual([
-          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] } },
           { '/_components/foo/instances/1': { a: 'b' }},
           { '/_layouts/layout/instances/1': { main: 'main' }}, // only appears once
+          { '/_pages/foo': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/1'] } },
+          { '/_components/foo/instances/2': { c: 'd' }},
           { '/_pages/bar': { layout: '/_layouts/layout/instances/1', main: ['/_components/foo/instances/2'] } },
-          { '/_components/foo/instances/2': { c: 'd' }}
         ]);
         lib.clearLayouts();
       });
@@ -315,7 +321,10 @@ describe('export', () => {
       }));
       fetch.mockResponseOnce(JSON.stringify({ a: 'b' }));
       return lib.fromURL('http://domain.com/some-slug', { concurrency }).collect().toPromise(Promise).then((res) => {
-        expect(res).toEqual([{ '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] } }, { '/_components/foo/instances/1': { a: 'b' }}]);
+        expect(res).toEqual([
+          { '/_components/foo/instances/1': { a: 'b' }},
+          { '/_pages/foo': { layout: '/_components/layout/instances/1', main: ['/_components/foo/instances/1'] } }
+        ]);
       });
     });
 


### PR DESCRIPTION
I ran into an issue using the programmatic API attempt to pass the stream from `clayCli.export.fromUrl` into a `clayCli.import` with `{publish: true}` passed as an option.  It was unsuccessful at publishing the page, because the `import` would attempt to PUT to the @published uri of the page before it would PUT the draft versions of the components inside of that page.  Instead, this will export pages AFTER components and layout on the page, instead of before them.