### PR TITLE
Memoizing Safe Load For Bootstrap Parse

### DIFF
--- a/lib/cmd/import.js
+++ b/lib/cmd/import.js
@@ -7,6 +7,7 @@ const _ = require('lodash'),
   prefixes = require('../prefixes'),
   config = require('./config'),
   rest = require('../rest'),
+  memSafeLoad = _.memoize(yaml.safeLoad),
   DEFAULT_CONCURRENCY = 10;
 
 /**
@@ -179,7 +180,7 @@ function parseBootstrap(str, url) {
   const prefix = config.get('url', url);
 
   return h.of(str)
-    .map(yaml.safeLoad)
+    .map(memSafeLoad)
     .errors((e, push) => push(new Error(`YAML syntax error: ${e.message.slice(0, e.message.indexOf(':'))}`)))
     .flatMap((obj) => formatting.toDispatch(h.of(obj)))
     .flatMap((dispatch) => prefixes.add(dispatch, prefix));


### PR DESCRIPTION
When parsing bootstraps you can sometimes have the same yaml send to `parseBootstrap` multiple times, like during amphora startup. 