### PR TITLE
fix import by making support more explicit

### DIFF
--- a/lib/cmd/import.js
+++ b/lib/cmd/import.js
@@ -75,6 +75,28 @@ function importDispatch(obj, prefix, key, options) {
 }
 
 /**
+ * format the source when parsing dispatches
+ * @param  {string|Buffer|object|Stream} source
+ * @return {Stream}
+ */
+function formatDispatchSource(source) {
+  if (_.isString(source)) {
+    // handle importing from strings, e.g. when piping files into claycli
+    return h.of(source).split().compact();
+  } else if (Buffer.isBuffer(source)) {
+    // handle importing from buffers, e.g. when piping claycli export into claycli import
+    return h.of(source.toString('utf8')).split().compact();
+  } else if (_.isObject(source) && typeof source.pipe !== 'function') {
+    // handle importing from objects (that aren't streams), e.g. when programmatically piping claycli export into claycli import
+    // note: we're duck-typing for streams by checking if it has a .pipe function
+    return h.of(source);
+  } else {
+    // handle importing from streams of strings
+    return h(source).split().compact();
+  }
+}
+
+/**
  * import data into clay
  * @param  {string|object|Buffer|Stream} str (stream of) bootstraps or dispatches
  * @param  {string} url to import to (must be a site prefix)
@@ -140,25 +162,8 @@ function importItems(str, url, options = {}) {
         }
       }).parallel(concurrency);
   } else {
-    let stream;
-
-    if (_.isString(str)) {
-      // handle importing from strings, e.g. when piping files into claycli
-      stream = h.of(str).split().compact();
-    } else if (Buffer.isBuffer(str)) {
-      // handle importing from buffers, e.g. when piping claycli export into claycli import
-      stream = h.of(str.toString('utf8')).split().compact();
-    } else if (_.isObject(str) && typeof str.pipe !== 'function') {
-      // handle importing from objects (that aren't streams), e.g. when programmatically piping claycli export into claycli import
-      // note: we're duck-typing for streams by checking if it has a .pipe function
-      stream = h.of(str);
-    } else {
-      // handle importing from streams of strings
-      stream = h(str).split().compact();
-    }
-
     // parse dispatches
-    return stream
+    return formatDispatchSource(str)
       .map((res) => {
         try {
           return _.isString(res) ? JSON.parse(res) : res; // allow strings or objects

--- a/lib/cmd/import.js
+++ b/lib/cmd/import.js
@@ -76,7 +76,7 @@ function importDispatch(obj, prefix, key, options) {
 
 /**
  * import data into clay
- * @param  {string|Stream} str (stream of) bootstraps or dispatches
+ * @param  {string|object|Buffer|Stream} str (stream of) bootstraps or dispatches
  * @param  {string} url to import to (must be a site prefix)
  * @param  {Object} [options={}]
  * @param  {string} [options.key] api key or alias
@@ -140,14 +140,31 @@ function importItems(str, url, options = {}) {
         }
       }).parallel(concurrency);
   } else {
+    let stream;
+
+    if (_.isString(str)) {
+      // handle importing from strings, e.g. when piping files into claycli
+      stream = h.of(str).split().compact();
+    } else if (Buffer.isBuffer(str)) {
+      // handle importing from buffers, e.g. when piping claycli export into claycli import
+      stream = h.of(str.toString('utf8')).split().compact();
+    } else if (_.isObject(str) && typeof str.pipe !== 'function') {
+      // handle importing from objects (that aren't streams), e.g. when programmatically piping claycli export into claycli import
+      // note: we're duck-typing for streams by checking if it has a .pipe function
+      stream = h.of(str);
+    } else {
+      // handle importing from streams of strings
+      stream = h(str).split().compact();
+    }
+
     // parse dispatches
-    return (_.isString(str) ? h.of(str).split().compact() : h(str))
+    return stream
       .map((res) => {
         try {
           return _.isString(res) ? JSON.parse(res) : res; // allow strings or objects
         } catch (e) {
           try {
-            yaml.safeLoad(str);
+            yaml.safeLoad(res);
             // user accidentally tried to import dispatches from a yaml file!
             return { type: 'error', message: 'Cannot import dispatch from yaml', details: 'Please use the --yaml argument to import from bootstraps' };
           } catch (otherE) {

--- a/lib/cmd/import.test.js
+++ b/lib/cmd/import.test.js
@@ -57,9 +57,23 @@ describe('import', () => {
     });
   });
 
-  it('imports dispatch from stream of objects', () => {
+  it('imports dispatch from buffer', () => {
     fetch.mockResponseOnce('{}');
-    return lib(h.of({ '/_components/obj': { b: 'c' } }), url, { key, concurrency }).collect().toPromise(Promise).then((res) => {
+    return lib(Buffer.from(JSON.stringify({ '/_components/a': { b: 'c' } })), url, { key, concurrency }).collect().toPromise(Promise).then((res) => {
+      expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_components/a' }]);
+    });
+  });
+
+  it('imports dispatch from string', () => {
+    fetch.mockResponseOnce('{}');
+    return lib(JSON.stringify({ '/_components/a': { b: 'c' } }), url, { key, concurrency }).collect().toPromise(Promise).then((res) => {
+      expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_components/a' }]);
+    });
+  });
+
+  it('imports dispatch from object', () => {
+    fetch.mockResponseOnce('{}');
+    return lib({ '/_components/obj': { b: 'c' } }, url, { key, concurrency }).collect().toPromise(Promise).then((res) => {
       expect(res).toEqual([{ type: 'success', message: 'http://domain.com/_components/obj' }]);
     });
   });


### PR DESCRIPTION
* pulls out `import` handling logic to make it more clear
* we handle importing from `stream of strings`, `string`, `object`, and `Buffer` (the last one was causing an issue with v3.4.x)