### PR TITLE
enable npm component template precompilation

### DIFF
--- a/lib/cmd/compile/templates.js
+++ b/lib/cmd/compile/templates.js
@@ -3,6 +3,7 @@ const _ = require('lodash'),
   h = require('highland'),
   glob = require('glob'),
   fs = require('fs-extra'),
+  afs = require('amphora-fs'),
   path = require('path'),
   gulp = require('gulp'),
   rename = require('gulp-rename'),
@@ -18,7 +19,8 @@ const _ = require('lodash'),
   destPath = path.join(process.cwd(), 'public', 'js'),
   templateGlob = 'template.+(hbs|handlebars)',
   variables = { minify: process.env.CLAYCLI_COMPILE_MINIFIED || process.env.CLAYCLI_COMPILE_MINIFIED_TEMPLATES },
-  sourcePaths = [path.join(process.cwd(), 'components', '**', templateGlob), path.join(process.cwd(), 'layouts', '**', templateGlob)],
+  componentPaths = afs.getComponents().map((name) => path.join(afs.getComponentPath(name), templateGlob)),
+  sourcePaths = componentPaths.concat([path.join(process.cwd(), 'layouts', '**', templateGlob)]),
   // bundles for group concatenating (when minifying)
   bundles = helpers.generateBundles('_templates', 'js'),
   getFileCtime = _.memoize((filepath) => fs.statSync(filepath).ctime);
@@ -183,9 +185,9 @@ function compile(options = {}) {
   }
 
   gulp.task('templates', () => {
-    return h(gulp.src(sourcePaths)
+    return h(gulp.src(sourcePaths, { base: process.cwd() })
       .pipe(rename((filepath) => {
-        const name = filepath.dirname;
+        const name = _.last(filepath.dirname.split(path.sep));
 
         filepath.dirname = '';
         filepath.basename = `${name}.template`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2257,7 +2257,7 @@
         "@babel/helper-split-export-declaration": "7.0.0-beta.44",
         "@babel/types": "7.0.0-beta.44",
         "babylon": "7.0.0-beta.44",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "globals": "11.7.0",
         "invariant": "2.2.3",
         "lodash": "4.17.5"
@@ -2287,17 +2287,22 @@
           "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g=="
         },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.1"
           }
         },
         "globals": {
           "version": "11.7.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
           "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },
@@ -2319,9 +2324,9 @@
       }
     },
     "@nymag/vueify": {
-      "version": "9.4.4",
-      "resolved": "https://registry.npmjs.org/@nymag/vueify/-/vueify-9.4.4.tgz",
-      "integrity": "sha512-cQXaXON1JP5XlaXO21/YXX9o2hEWwODE4Cklo57wFX2Cv4k2ijgC5itHGEI5/Y2wf5J1Wt/pmR8Ii0bvqcIXLA==",
+      "version": "9.4.5",
+      "resolved": "https://registry.npmjs.org/@nymag/vueify/-/vueify-9.4.5.tgz",
+      "integrity": "sha512-SwuRMCfVADGWgorSwiRUKKYAIo5q5RqMnP6VxichzEbWaLzriDKU+XA+3zZzxe+A1sqdb+IVHcDxnL1O6sbB7w==",
       "requires": {
         "chalk": "1.1.3",
         "convert-source-map": "1.5.1",
@@ -4223,7 +4228,7 @@
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000884",
+        "caniuse-db": "1.0.30000885",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -4233,7 +4238,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000884",
+            "caniuse-db": "1.0.30000885",
             "electron-to-chromium": "1.3.52"
           }
         },
@@ -4245,9 +4250,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000884",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000884.tgz",
-      "integrity": "sha512-jVcZPhqrsyohOBAoYpf87mfKIL80XtQH9B1XQ3Ac8nMUKGld+QuFtc+ZaXKAUlE9o8vYLlUAooihB30VRPu0rA=="
+      "version": "1.0.30000885",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000885.tgz",
+      "integrity": "sha512-Hy1a+UIXooG+tRlt3WnT9avMf+l999bR9J1MqlQdYKgbsYjKxV4a4rgcmiyMmdCLPBFsiRoDxdl9tnNyaq2RXw=="
     },
     "caniuse-lite": {
       "version": "1.0.30000865",
@@ -5345,7 +5350,7 @@
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000884",
+            "caniuse-db": "1.0.30000885",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.18",
@@ -5357,7 +5362,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000884",
+            "caniuse-db": "1.0.30000885",
             "electron-to-chromium": "1.3.52"
           }
         },
@@ -12828,7 +12833,7 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000884",
+            "caniuse-db": "1.0.30000885",
             "electron-to-chromium": "1.3.52"
           }
         },


### PR DESCRIPTION
due to some technical issues with precompilation and `gulp-group-concat`, we didn't launch `clay compile templates` with proper template compilation for components on `npm`. This addresses that.