### PR TITLE
call amphora-fs in methods

### DIFF
--- a/lib/cmd/compile/media.js
+++ b/lib/cmd/compile/media.js
@@ -8,11 +8,7 @@ const _ = require('lodash'),
   changed = require('gulp-changed'),
   es = require('event-stream'),
   destPath = path.join(process.cwd(), 'public', 'media'),
-  mediaGlobs = '*.+(jpg|jpeg|png|gif|webp|svg|ico)',
-  componentsSrc = afs.getComponents().map((comp) => ({ name: comp, path: path.join(afs.getComponentPath(comp), 'media', mediaGlobs) })),
-  layoutsSrc = afs.getLayouts().map((layout) => ({ name: layout, path: path.join(process.cwd(), 'layouts', layout, 'media', mediaGlobs) })),
-  styleguidesSrc = afs.getFolders(path.join(process.cwd(), 'styleguides')).map((styleguide) => ({ name: styleguide, path: path.join(process.cwd(), 'styleguides', styleguide, 'media', mediaGlobs) })),
-  sitesSrc = afs.getFolders(path.join(process.cwd(), 'sites')).map((site) => ({ name: site, path: path.join(process.cwd(), 'sites', site, 'media', mediaGlobs) }));
+  mediaGlobs = '*.+(jpg|jpeg|png|gif|webp|svg|ico)';
 
 /**
  * copy images and icons from components, layouts, styleguide, and sites folders
@@ -22,6 +18,11 @@ const _ = require('lodash'),
  * @return {Object} with build (Highland Stream) and watch (Chokidar instance)
  */
 function compile(options = {}) {
+  const componentsSrc = afs.getComponents().map((comp) => ({ name: comp, path: path.join(afs.getComponentPath(comp), 'media', mediaGlobs) })),
+    layoutsSrc = afs.getLayouts().map((layout) => ({ name: layout, path: path.join(process.cwd(), 'layouts', layout, 'media', mediaGlobs) })),
+    styleguidesSrc = afs.getFolders(path.join(process.cwd(), 'styleguides')).map((styleguide) => ({ name: styleguide, path: path.join(process.cwd(), 'styleguides', styleguide, 'media', mediaGlobs) })),
+    sitesSrc = afs.getFolders(path.join(process.cwd(), 'sites')).map((site) => ({ name: site, path: path.join(process.cwd(), 'sites', site, 'media', mediaGlobs) }));
+
   let watch = options.watch || false;
 
   gulp.task('media', () => {

--- a/lib/cmd/compile/templates.js
+++ b/lib/cmd/compile/templates.js
@@ -19,8 +19,6 @@ const _ = require('lodash'),
   destPath = path.join(process.cwd(), 'public', 'js'),
   templateGlob = 'template.+(hbs|handlebars)',
   variables = { minify: process.env.CLAYCLI_COMPILE_MINIFIED || process.env.CLAYCLI_COMPILE_MINIFIED_TEMPLATES },
-  componentPaths = afs.getComponents().map((name) => path.join(afs.getComponentPath(name), templateGlob)),
-  sourcePaths = componentPaths.concat([path.join(process.cwd(), 'layouts', '**', templateGlob)]),
   // bundles for group concatenating (when minifying)
   bundles = helpers.generateBundles('_templates', 'js'),
   getFileCtime = _.memoize((filepath) => fs.statSync(filepath).ctime);
@@ -177,6 +175,9 @@ function minifyTemplate(file, shouldMinify) {
  * @return {Object} with build (Highland Stream) and watch (Chokidar instance)
  */
 function compile(options = {}) {
+  const componentPaths = afs.getComponents().map((name) => path.join(afs.getComponentPath(name), templateGlob)),
+    sourcePaths = componentPaths.concat([path.join(process.cwd(), 'layouts', '**', templateGlob)]);
+
   let watch = options.watch || false,
     minify = options.minify || variables.minify || false;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2560,9 +2560,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "amphora-fs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amphora-fs/-/amphora-fs-1.0.1.tgz",
-      "integrity": "sha512-ZYCvWkgQL6ooDfYIh5wM7+kBUmPObwBm3Wz6G02HBKL5jZWKJWciIkNvuQPTrkcHYXBFBeKmxxMjAqCUPSFS/Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/amphora-fs/-/amphora-fs-1.0.2.tgz",
+      "integrity": "sha512-j/RrT2iWxs6VH7bP4l7c91JJNM54ZYf1Nr/7MR9cw0wmhnee/3a/unuLi4yeb+b1ssIsfzlP8/bvtyFhUq8gog==",
       "requires": {
         "clayutils": "2.5.0",
         "js-yaml": "3.12.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
     "@nymag/vueify": "^9.4.5",
-    "amphora-fs": "^1.0.1",
+    "amphora-fs": "^1.0.2",
     "autoprefixer": "^9.0.2",
     "babelify": "^10.0.0",
     "base-64": "^0.1.0",


### PR DESCRIPTION
fixes #95, allows `claycli` to be used anywhere (not just in a clay repo). Note that `clay compile` must still be used in a clay repo to compile assets for that repo.