### PR TITLE
use global > 3% browserslist for autoprefixer and babel

### DIFF
--- a/lib/cmd/compile/scripts.js
+++ b/lib/cmd/compile/scripts.js
@@ -52,7 +52,7 @@ const _ = require('lodash'),
   },
   babelConfig = {
     // force babel to resolve the preset from claycli's node modules rather than the clay install's repo
-    presets: [[require('@babel/preset-env'), { targets: '> 0.25%, not dead'}]]
+    presets: [[require('@babel/preset-env'), { targets: helpers.browserslist }]]
   },
   temporaryIDs = {};
 
@@ -322,7 +322,7 @@ function buildScripts(entries, options = {}) {
       babel: babelConfig,
       postcss: [
         cssImport(),
-        autoprefixer(helpers.autoprefixOptions),
+        autoprefixer(helpers.browserslist),
         mixins(),
         nested(),
         simpleVars()

--- a/lib/cmd/compile/styles.js
+++ b/lib/cmd/compile/styles.js
@@ -115,7 +115,7 @@ function compile(options = {}) {
       .pipe(rename(renameFile))
       .pipe(postcss([
         cssImport(),
-        autoprefixer(helpers.autoprefixOptions),
+        autoprefixer(helpers.browserslist),
         mixins(),
         nested(),
         simpleVars({ variables })

--- a/lib/compilation-helpers.js
+++ b/lib/compilation-helpers.js
@@ -128,7 +128,7 @@ module.exports.unbucket = unbucket;
 module.exports.generateBundles = generateBundles;
 module.exports.hasChanged = hasChanged;
 module.exports.transformPath  = transformPath;
-module.exports.autoprefixOptions = { browsers: ['last 2 versions', 'ie >= 9', 'ios >= 7', 'android >= 4.4.2'] }; // used by styles and vueify (kiln plugin templates)
+module.exports.browserslist = { browsers: ['> 3%'] }; // used by styles, and vueify, and babel/preset-env
 
 // for testing
 module.exports.watcher = watcher;

--- a/lib/compilation-helpers.js
+++ b/lib/compilation-helpers.js
@@ -128,7 +128,7 @@ module.exports.unbucket = unbucket;
 module.exports.generateBundles = generateBundles;
 module.exports.hasChanged = hasChanged;
 module.exports.transformPath  = transformPath;
-module.exports.browserslist = { browsers: ['> 3%'] }; // used by styles, and vueify, and babel/preset-env
+module.exports.browserslist = { browsers: ['> 3%', 'not and_uc > 0'] }; // used by styles, and vueify, and babel/preset-env
 
 // for testing
 module.exports.watcher = watcher;


### PR DESCRIPTION
This will target all browsers with > 3% global market share, which just so happen to be modern browsers whom'st support es6 syntax and unprefixed css3 rules. Currently (as of Sept 2018) they are:

* android chrome 67
* chrome 67 (+68)
* firefox 61
* ios safari 11.3

Note: we're purposefully excluding UC Browser (a popular chinese browser) because it is a very (_very_) popular malware vector.