### PR TITLE
Swapping Plugin Ordering

### DIFF
--- a/lib/cmd/compile/styles.js
+++ b/lib/cmd/compile/styles.js
@@ -117,6 +117,8 @@ function compile(options = {}) {
         cssImport(),
         autoprefixer(helpers.browserslist),
         mixins(),
+        // Simple vars must come before `nested` so that string interpolation of variables occurs before
+        // the nesting is parsed. This ensures being able to use variables in class names of nested selectors
         simpleVars({ variables }),
         nested()
       ].concat(plugins)))

--- a/lib/cmd/compile/styles.js
+++ b/lib/cmd/compile/styles.js
@@ -117,8 +117,8 @@ function compile(options = {}) {
         cssImport(),
         autoprefixer(helpers.browserslist),
         mixins(),
-        nested(),
-        simpleVars({ variables })
+        simpleVars({ variables }),
+        nested()
       ].concat(plugins)))
       .pipe(gulpIf(minify, cssmin()))
       .pipe(gulp.dest(destPath))


### PR DESCRIPTION
Allows for interpolation of variables before parsing of nested values.