### PR TITLE
Custom Task

### DIFF
--- a/cli/compile/custom-tasks.js
+++ b/cli/compile/custom-tasks.js
@@ -9,25 +9,22 @@ const pluralize = require('pluralize'),
 function builder(yargs) {
   return yargs
     .usage('Usage: $0 custom-tasks')
-    .example('$0 custom-tasks', 'run custom gulp tasks defined in the claycli.config.js file')
+    .example('$0 custom-tasks', 'run custom tasks defined in the claycli.config.js file `customTasks` property')
     .option('r', options.reporter);
 }
 
 function handler(argv) {
-  const t1 = Date.now(),
-    compiled = compile.customTasks({
-      watch: argv.watch,
-      minify: argv.minify,
-      inlined: argv.inlined,
-      linked: argv.linked
-    });
-
-  console.log('foo')
+  compile.customTasks({
+    watch: argv.watch,
+    minify: argv.minify,
+    inlined: argv.inlined,
+    linked: argv.linked
+  });
 }
 
 module.exports = {
   command: 'custom-tasks',
-  describe: 'Run any custom tasks',
+  describe: 'Run any custom tasks. Each task will be wrapped by Gulp',
   builder,
   handler
 };

--- a/cli/compile/custom-tasks.js
+++ b/cli/compile/custom-tasks.js
@@ -27,9 +27,9 @@ function handler() {
         if (task.type === 'success') {
           term.status.ok(`Successfully ran task: ${task.name}`);
         } else {
-          term.cross(`Error running task: ${task.error.stack}`)
+          term.cross(`Error running task: ${task.error.stack}`);
         }
-      })
+      });
     });
 }
 

--- a/cli/compile/custom-tasks.js
+++ b/cli/compile/custom-tasks.js
@@ -1,0 +1,51 @@
+'use strict';
+const pluralize = require('pluralize'),
+  compile = require('../../lib/cmd/compile'),
+  options = require('../cli-options'),
+  reporter = require('../../lib/reporters'),
+  helpers = require('../../lib/compilation-helpers');
+
+function builder(yargs) {
+  return yargs
+    .usage('Usage: $0 custom-tasks')
+    .example('$0 custom-tasks', 'run custom gulp tasks defined in the claycli.config.js file')
+    .option('r', options.reporter);
+}
+
+function handler(argv) {
+
+  console.log('foo')
+  // const t1 = Date.now(),
+  //   compiled = compile.fonts({
+  //     watch: argv.watch,
+  //     minify: argv.minify,
+  //     inlined: argv.inlined,
+  //     linked: argv.linked
+  //   });
+
+  // return compiled.build
+  //   .map(reporter.logAction(argv.reporter, 'fonts'))
+  //   .toArray((results) => {
+  //     const t2 = Date.now();
+
+  //     reporter.logSummary(argv.reporter, 'fonts', (successes) => {
+  //       let message = `Compiled ${pluralize('font', successes, true)} in ${helpers.time(t2, t1)}`;
+
+  //       if (compiled.watch) {
+  //         message += '\nWatching for changes...';
+  //       }
+  //       return { success: true, message };
+  //     })(results);
+
+  //     if (compiled.watch) {
+  //       compiled.watch.on('raw', helpers.debouncedWatcher);
+  //     }
+  //   });
+}
+
+module.exports = {
+  command: 'custom-tasks',
+  describe: 'Run any custom tasks',
+  builder,
+  handler
+};

--- a/cli/compile/custom-tasks.js
+++ b/cli/compile/custom-tasks.js
@@ -1,6 +1,7 @@
 'use strict';
 const pluralize = require('pluralize'),
   compile = require('../../lib/cmd/compile'),
+
   options = require('../cli-options'),
   reporter = require('../../lib/reporters'),
   helpers = require('../../lib/compilation-helpers');
@@ -13,34 +14,15 @@ function builder(yargs) {
 }
 
 function handler(argv) {
+  const t1 = Date.now(),
+    compiled = compile.customTasks({
+      watch: argv.watch,
+      minify: argv.minify,
+      inlined: argv.inlined,
+      linked: argv.linked
+    });
 
   console.log('foo')
-  // const t1 = Date.now(),
-  //   compiled = compile.fonts({
-  //     watch: argv.watch,
-  //     minify: argv.minify,
-  //     inlined: argv.inlined,
-  //     linked: argv.linked
-  //   });
-
-  // return compiled.build
-  //   .map(reporter.logAction(argv.reporter, 'fonts'))
-  //   .toArray((results) => {
-  //     const t2 = Date.now();
-
-  //     reporter.logSummary(argv.reporter, 'fonts', (successes) => {
-  //       let message = `Compiled ${pluralize('font', successes, true)} in ${helpers.time(t2, t1)}`;
-
-  //       if (compiled.watch) {
-  //         message += '\nWatching for changes...';
-  //       }
-  //       return { success: true, message };
-  //     })(results);
-
-  //     if (compiled.watch) {
-  //       compiled.watch.on('raw', helpers.debouncedWatcher);
-  //     }
-  //   });
 }
 
 module.exports = {

--- a/cli/compile/index.js
+++ b/cli/compile/index.js
@@ -15,6 +15,7 @@ function builder(yargs) {
     .command(require('./styles'))
     .command(require('./templates'))
     .command(require('./scripts'))
+    // .command(require('./custom-tasks'))
     .example('$0 compile', 'compile all assets')
     .example('$0 compile --watch', 'compile and watch all assets')
     .option('w', options.watch)

--- a/cli/compile/index.js
+++ b/cli/compile/index.js
@@ -15,7 +15,7 @@ function builder(yargs) {
     .command(require('./styles'))
     .command(require('./templates'))
     .command(require('./scripts'))
-    // .command(require('./custom-tasks'))
+    .command(require('./custom-tasks'))
     .example('$0 compile', 'compile all assets')
     .example('$0 compile --watch', 'compile and watch all assets')
     .option('w', options.watch)

--- a/index.js
+++ b/index.js
@@ -7,3 +7,4 @@ module.exports.lint = require('./lib/cmd/lint');
 module.exports.import = require('./lib/cmd/import');
 module.exports.export = require('./lib/cmd/export');
 module.exports.compile = require('./lib/cmd/compile');
+module.exports.gulp = require('gulp'); // A reference to the Gulp instance so that external tasks can reference a common package

--- a/lib/cmd/compile/custom-tasks.js
+++ b/lib/cmd/compile/custom-tasks.js
@@ -14,7 +14,7 @@ function compile() {
     stream = h(tasks) // Wrap in highland
       .map(task => {
         return h(task.fn()) // Excute task and wrap in highland
-          .map(() => ({ type: 'success', name: task.name })) // If successful return a formatted object
+          .map(() => ({ type: 'success', name: task.name })); // If successful return a formatted object
       })
       .merge(); // Flatten out the streams into one
 

--- a/lib/cmd/compile/custom-tasks.js
+++ b/lib/cmd/compile/custom-tasks.js
@@ -23,5 +23,4 @@ function compile() {
   };
 }
 
-
 module.exports = compile;

--- a/lib/cmd/compile/custom-tasks.js
+++ b/lib/cmd/compile/custom-tasks.js
@@ -1,23 +1,27 @@
 'use strict';
-const gulp = require('gulp'),
+
+const h = require('highland'),
   config = require('../../config-file-helpers');
 
 /**
- * Runs custom tasks!
+ * Runs custom Gulp tasks defined in the claycli.config.js
+ * file inside the project
+ *
+ * @return {Object} with build (Highland Stream)
  */
-function compile(options = {}) {
-  const tasks = config.getConfigValue('customTasks'),
-    series = tasks.map(task => {
-      console.log(`Found task... ${task.name}`);
-      gulp.task(task.name, task.fn);
-      return task.fn;
-    });
+function compile() {
+  const tasks = config.getConfigValue('customTasks') || [], // grab the tasks
+    stream = h(tasks) // Wrap in highland
+      .map(task => {
+        return h(task.fn()) // Excute task and wrap in highland
+          .map(() => ({ type: 'success', name: task.name })) // If successful return a formatted object
+      })
+      .merge(); // Flatten out the streams into one
 
-  console.log(`Running ${tasks.length} tasks!`)
   return {
-    build: gulp.series(series)(),
-    watch: null
+    build: stream
   };
 }
+
 
 module.exports = compile;

--- a/lib/cmd/compile/custom-tasks.js
+++ b/lib/cmd/compile/custom-tasks.js
@@ -1,19 +1,9 @@
 'use strict';
 const gulp = require('gulp'),
-  _ = require('lodash'),
-  h = require('highland'),
-  // es = require('event-stream'),
   config = require('../../config-file-helpers');
 
 /**
- * compile fonts from styleguides/* to public/css
- * note: linked font files are copied to public/fonts
- * @param {object} [options]
- * @param {boolean} [options.minify] minify resulting css
- * @param {boolean} [options.watch] watch mode
- * @param {boolean} [options.inlined] compile base64-inlinedd font css
- * @param {boolean} [options.linked] compile linked font css (defaults to true, unless inlined is set)
- * @return {Object} with build (Highland Stream) and watch (Chokidar instance)
+ * Runs custom tasks!
  */
 function compile(options = {}) {
   const tasks = config.getConfigValue('customTasks'),

--- a/lib/cmd/compile/custom-tasks.js
+++ b/lib/cmd/compile/custom-tasks.js
@@ -1,32 +1,9 @@
 'use strict';
-const _ = require('lodash'),
+const gulp = require('gulp'),
+  _ = require('lodash'),
   h = require('highland'),
-  es = require('event-stream');
-
-function buildPipeline() {
-  // loop through the styleguides, generate gulp workflows that we'll later merge together
-  let tasks = _.reduce(styleguides, (streams, styleguide) => {
-    let fontsSrc = path.join(sourcePath, styleguide, 'fonts', `*.{${fontFormats.join(',')}}`),
-      inlinedFontsTask, linkedFontsTask;
-
-
-      // // define inlined fonts task
-      // inlinedFontsTask = gulp.src(fontsSrc)
-      //   // if a font in the styleguide is changed, recompile the result file
-      //   .pipe(newer({ dest: path.join(destPath, 'css', `_inlined-fonts.${styleguide}.css`), ctime: true }))
-      //   .pipe(es.mapSync((file) => getFontCSS(file, styleguide, true)))
-      //   .pipe(concat(`_inlined-fonts.${styleguide}.css`))
-      //   .pipe(gulpIf(minify, cssmin()))
-      //   .pipe(gulp.dest(path.join(destPath, 'css')))
-      //   .pipe(es.mapSync((file) => ({ type: 'success', message: file.path })));
-      // streams.push(inlinedFontsTask);
-
-
-    return streams;
-  }, []);
-
-  return es.merge(tasks);
-}
+  // es = require('event-stream'),
+  config = require('../../config-file-helpers');
 
 /**
  * compile fonts from styleguides/* to public/css
@@ -39,13 +16,16 @@ function buildPipeline() {
  * @return {Object} with build (Highland Stream) and watch (Chokidar instance)
  */
 function compile(options = {}) {
-  // gulp.task('custom-tasks', () => {
-  //   return h(buildPipeline());
-  // });
+  const tasks = config.getConfigValue('customTasks'),
+    series = tasks.map(task => {
+      console.log(`Found task... ${task.name}`);
+      gulp.task(task.name, task.fn);
+      return task.fn;
+    });
 
+  console.log(`Running ${tasks.length} tasks!`)
   return {
-    // build: gulp.task('fonts')(),
-    build: () => {},
+    build: gulp.series(series)(),
     watch: null
   };
 }

--- a/lib/cmd/compile/custom-tasks.js
+++ b/lib/cmd/compile/custom-tasks.js
@@ -1,0 +1,53 @@
+'use strict';
+const _ = require('lodash'),
+  h = require('highland'),
+  es = require('event-stream');
+
+function buildPipeline() {
+  // loop through the styleguides, generate gulp workflows that we'll later merge together
+  let tasks = _.reduce(styleguides, (streams, styleguide) => {
+    let fontsSrc = path.join(sourcePath, styleguide, 'fonts', `*.{${fontFormats.join(',')}}`),
+      inlinedFontsTask, linkedFontsTask;
+
+
+      // // define inlined fonts task
+      // inlinedFontsTask = gulp.src(fontsSrc)
+      //   // if a font in the styleguide is changed, recompile the result file
+      //   .pipe(newer({ dest: path.join(destPath, 'css', `_inlined-fonts.${styleguide}.css`), ctime: true }))
+      //   .pipe(es.mapSync((file) => getFontCSS(file, styleguide, true)))
+      //   .pipe(concat(`_inlined-fonts.${styleguide}.css`))
+      //   .pipe(gulpIf(minify, cssmin()))
+      //   .pipe(gulp.dest(path.join(destPath, 'css')))
+      //   .pipe(es.mapSync((file) => ({ type: 'success', message: file.path })));
+      // streams.push(inlinedFontsTask);
+
+
+    return streams;
+  }, []);
+
+  return es.merge(tasks);
+}
+
+/**
+ * compile fonts from styleguides/* to public/css
+ * note: linked font files are copied to public/fonts
+ * @param {object} [options]
+ * @param {boolean} [options.minify] minify resulting css
+ * @param {boolean} [options.watch] watch mode
+ * @param {boolean} [options.inlined] compile base64-inlinedd font css
+ * @param {boolean} [options.linked] compile linked font css (defaults to true, unless inlined is set)
+ * @return {Object} with build (Highland Stream) and watch (Chokidar instance)
+ */
+function compile(options = {}) {
+  // gulp.task('custom-tasks', () => {
+  //   return h(buildPipeline());
+  // });
+
+  return {
+    // build: gulp.task('fonts')(),
+    build: () => {},
+    watch: null
+  };
+}
+
+module.exports = compile;

--- a/lib/cmd/compile/index.js
+++ b/lib/cmd/compile/index.js
@@ -5,3 +5,4 @@ module.exports.media = require('./media');
 module.exports.styles = require('./styles');
 module.exports.templates = require('./templates');
 module.exports.scripts = require('./scripts');
+module.exports.scripts = require('./custom-tasks');

--- a/lib/cmd/compile/index.js
+++ b/lib/cmd/compile/index.js
@@ -5,4 +5,4 @@ module.exports.media = require('./media');
 module.exports.styles = require('./styles');
 module.exports.templates = require('./templates');
 module.exports.scripts = require('./scripts');
-module.exports.scripts = require('./custom-tasks');
+module.exports.customTasks = require('./custom-tasks');


### PR DESCRIPTION
#112 

Opening early so we can make sure this matches with what we think will be needed in the future.

## Quick Points

- Allows for registering custom tasks in the `claycli.config.js` file
- Command is `clay compile custom-tasks`
- Tasks are run in a `series`, not `parallel` (No real reason, just first pass)

## More discussion

- Logging
- Command name
- Parallel
- Should there be a folder for custom tasks rather than the cli config file or should that be the discretion of the implementation?/
- What args should be passed to the task? Any? The defaults claycli asks for?

## Sample Config File Task

Sample pulled from real life gulp task. Args are available via the yargs module in this task, so maybe we don't need to pass anything in.

```javascript
'use strict';

var gulp = require('gulp'),
  concat = require('gulp-concat'),
  uglify = require('gulp-uglify'),
  gutil = require('gulp-util'),
  argv = require('yargs').argv,
  gulpif = require('gulp-if');

module.exports = {
  customTasks: [
    {
      name: 'polyfills',
      fn: () => {
        return gulp.src([
          'global/polyfills.js',
          'global/modernizr.js'
        ])
        .pipe(concat('polyfills.js'))
        .pipe(gulpif(!argv.debug, uglify())).on('error', gutil.log)
        .pipe(gulp.dest('public/js'));
      }
    }
  ]
};

```