### PR TITLE
Temporarily Remove Compile Watch Optimizations

### DIFF
--- a/lib/cmd/compile/scripts.js
+++ b/lib/cmd/compile/scripts.js
@@ -462,7 +462,7 @@ function compile(options = {}) {
              * written with only the contents of a single file.  For the time
              * being we will rely on the `browserify-cache.json` file to allow
              * us to pass the entire set of entrypoints on watch recompilation.
-             * 
+             *
              * For example if we had some entrypoint like `/path/to/example.js`
              * which falls into `_deps-e-f.js`, everything other than example.js
              * would be removed from this deps file upon watch recompilation.

--- a/lib/cmd/compile/scripts.js
+++ b/lib/cmd/compile/scripts.js
@@ -455,7 +455,20 @@ function compile(options = {}) {
             buildKiln();
           } else {
             // recompile changed megabundled files
-            buildScripts([file], bundleOptions)
+            /**
+             * Previously the watch would only pass a single entrypoint to
+             * `buildScripts`, the issue with this was that with only a single
+             * entrypoint parts of the _deps, etc files would be entirely over
+             * written with only the contents of a single file.  For the time
+             * being we will rely on the `browserify-cache.json` file to allow
+             * us to pass the entire set of entrypoints on watch recompilation.
+             * 
+             * For example if we had some entrypoint like `/path/to/example.js`
+             * which falls into `_deps-e-f.js`, everything other than example.js
+             * would be removed from this deps file upon watch recompilation.
+             * @see https://github.com/clay/claycli/issues/116#issuecomment-454110714
+             */
+            buildScripts(bundleOptions.cache.files, bundleOptions)
               .then(function (result) {
                 _.map(result, reporters.logAction(reporter, 'compile'));
               });

--- a/lib/cmd/compile/templates.js
+++ b/lib/cmd/compile/templates.js
@@ -196,10 +196,25 @@ function compile(options = {}) {
         filepath.basename = `${name}.template`;
         filepath.extname = '.js';
       }))
+      /**
+       * Because there is no caching of templates like there is for scripts
+       * files when we exclude unchanged files we will overwrite the chunked
+       * template files with only the few templates which actually had
+       * changes detected.  For the time being we will remove the exclusion of
+       * unmodified templates, taking the performance penalty while
+       * maintaining correct construction of the chunked template files.
+       * 
+       * For example if we had some entrypoint like `/path/to/template.hbs`
+       * which falls into `_templates-t-z.js`, everything other than template.hbs
+       * would be removed from this deps file upon watch recompilation.
+       * @see https://github.com/clay/claycli/issues/116#issuecomment-454110714
+       */
+      /*
       .pipe(changed(destPath, {
         transformPath: helpers.transformPath('_templates', destPath, minify),
         hasChanged: hasTemplateChanged(minify)
       }))
+      */
       .pipe(es.mapSync(wrapTemplate))
       .pipe(es.mapSync(precompile))
       .pipe(es.mapSync(registerTemplate))

--- a/lib/cmd/compile/templates.js
+++ b/lib/cmd/compile/templates.js
@@ -1,13 +1,12 @@
 'use strict';
 const _ = require('lodash'),
   h = require('highland'),
-  glob = require('glob'),
+  // glob = require('glob'),
   fs = require('fs-extra'),
   afs = require('amphora-fs'),
   path = require('path'),
   gulp = require('gulp'),
   rename = require('gulp-rename'),
-  changed = require('gulp-changed'),
   groupConcat = require('gulp-group-concat'),
   es = require('event-stream'),
   clayHbs = require('clayhandlebars'),
@@ -21,8 +20,8 @@ const _ = require('lodash'),
   templateGlob = 'template.+(hbs|handlebars)',
   variables = { minify: process.env.CLAYCLI_COMPILE_MINIFIED || process.env.CLAYCLI_COMPILE_MINIFIED_TEMPLATES },
   // bundles for group concatenating (when minifying)
-  bundles = helpers.generateBundles('_templates', 'js'),
-  getFileCtime = _.memoize((filepath) => fs.statSync(filepath).ctime);
+  bundles = helpers.generateBundles('_templates', 'js');
+  // getFileCtime = _.memoize((filepath) => fs.statSync(filepath).ctime);
 
 /**
  * determine whether a template has changed
@@ -31,6 +30,7 @@ const _ = require('lodash'),
  * @param  {boolean}  minify
  * @return {Function}
  */
+/*
 function hasTemplateChanged(minify) {
   return (stream, sourceFile, targetPath) => {
     if (minify) {
@@ -67,6 +67,7 @@ function hasTemplateChanged(minify) {
     }
   };
 }
+*/
 
 /**
  * replace `{{{ read 'file' }}}` helper with inlined file contents,
@@ -203,7 +204,7 @@ function compile(options = {}) {
        * changes detected.  For the time being we will remove the exclusion of
        * unmodified templates, taking the performance penalty while
        * maintaining correct construction of the chunked template files.
-       * 
+       *
        * For example if we had some entrypoint like `/path/to/template.hbs`
        * which falls into `_templates-t-z.js`, everything other than template.hbs
        * would be removed from this deps file upon watch recompilation.


### PR DESCRIPTION
Optimizations in the watch for compile command `scripts` and `templates` caused issues where compiled script files would not contain their full context - see https://github.com/clay/claycli/issues/116 for more details.

This PR temporarily removes these optimizations so that watch commands work consistently

- For `scripts` pass all entrypoints through to `buildScripts`
- For `templates` do not exclude unmodified template files when recompiling for template files