### PR TITLE
Add a algolia config and secret

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -11,5 +11,5 @@ action "Filter branch" {
 action "Build and push docs" {
   needs = ["Filter branch"]
   uses = "clay/docusaurus-github-action@master"
-  secrets = ["DEPLOY_SSH_KEY"]
+  secrets = ["DEPLOY_SSH_KEY", "ALGOLIA_API_KEY"]
 }

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -55,7 +55,12 @@ const siteConfig = {
 
   // Open Graph and Twitter card images.
   ogImage: 'img/logo.svg',
-  twitterImage: 'img/logo.svg'
+  twitterImage: 'img/logo.svg',
+  algolia: {
+    apiKey: process.env.ALGOLIA_API_KEY,
+    indexName: 'claycli',
+    algoliaOptions: {} // Optional, if provided by Algolia
+  }
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Add `Algolia` search bar

# Steps for testing the site locally:
- Go to the `website` folder
- Install package using `npm install`
- Start your local server using `npm start`
- Go to [localhost](http://localhost:3000/claycli/docs/cli.html)
- Check on the top rigth corner of the page and will be a search input
- Compare with the current [docs page](https://clay.github.io/claycli/docs/cli.html)

## Intallation process:
https://docusaurus.io/docs/en/search

## Official Algolia site
https://community.algolia.com/docsearch/

Note:
We need the `Angolia` api key to create the secret and the `indexName`