### PR TITLE
Update the main.workflow file to add new action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,8 +8,12 @@ action "Filter branch" {
   args = "branch master"
 }
 
+action "Update version" {
+  uses = "clay/docusaurus-github-action/versions@master"
+}
+
 action "Build and push docs" {
-  needs = ["Filter branch"]
-  uses = "clay/docusaurus-github-action@master"
+  needs = ["Filter branch", "Update version"]
+  uses = "clay/docusaurus-github-action/build_deploy@master"
   secrets = ["DEPLOY_SSH_KEY", "ALGOLIA_API_KEY"]
 }


### PR DESCRIPTION
Update the `main.workflow` file to add a new path for the `Build and deploy` action and a new action to update the version of the docs

# Steps for testing the site locally:
- Install [act](https://github.com/nektos/act#installation)
- Go to the [`.github` ](https://github.com/clay/claycli/tree/git_action/.github) folder
- On the `main.workflow` update the[` branch`](https://github.com/clay/claycli/blob/git_action/.github/main.workflow?short_path=8c5ae9c#L7) line to use `branch action_version`
- Use the [`act`](https://github.com/nektos/act#commands) command to simulate a `push` event. The build should be `successful`
- On the `main.workflow` update the[` branch`](https://github.com/clay/claycli/blob/git_action/.github/main.workflow?short_path=8c5ae9c#L7) line to use `branch master`
- Use the [`act`](https://github.com/nektos/act#commands) command to simulate a `push` event.  The build should be `decline`

# Note
- ~We need to merge this [PR](https://github.com/clay/docusaurus-github-action/pull/2) first~