### PR TITLE
Update the gh-pages script and update the siteConfig default name

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,7 @@
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",
     "rename-version": "docusaurus-rename-version",
-    "deploy": "gh-pages -d build/clay-cli"
+    "deploy": "gh-pages -d build/claycli"
   },
   "devDependencies": {
     "docusaurus": "^1.7.2",

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -2,7 +2,7 @@
 // site configuration options.
 
 const repoUrl = 'https://github.com/clay/claycli',
-  projectName = process.env.PROJECT_NAME || 'site';
+  projectName = process.env.PROJECT_NAME || 'claycli';
 
 // List of projects/orgs using your project for the users page.
 const users = [


### PR DESCRIPTION
Update the `gh-pages` manual deploy script and the default option of the project name on the `SiteConfig`