### PR TITLE
check passed in value for key before defaulting to env var

### DIFF
--- a/lib/cmd/config.js
+++ b/lib/cmd/config.js
@@ -34,8 +34,8 @@ function getConfig(type, alias) {
   const fullConfig = config.load(configName);
 
   switch (type) {
-    case 'key': return _.get(fullConfig, `keys[${alias}]`) || process.env.CLAYCLI_DEFAULT_KEY || alias; // allow passing through actual keys
-    case 'url': return sanitizeUrl(_.get(fullConfig, `urls[${alias}]`) || process.env.CLAYCLI_DEFAULT_URL || alias); // sanitize url if we're actually passing it through
+    case 'key': return _.get(fullConfig, `keys[${alias}]`) || alias || process.env.CLAYCLI_DEFAULT_KEY; // allow passing through actual keys
+    case 'url': return sanitizeUrl(_.get(fullConfig, `urls[${alias}]`) || alias || process.env.CLAYCLI_DEFAULT_URL); // sanitize url if we're actually passing it through
     default: throw new Error(`Unknown config section "${type}"`);
   }
 }


### PR DESCRIPTION
check for a passed in key/url value before defaulting to the env var