### PR TITLE
transpile client-init because it runs on the client in view mode

### DIFF
--- a/lib/cmd/compile/scripts.js
+++ b/lib/cmd/compile/scripts.js
@@ -14,6 +14,7 @@ const _ = require('lodash'),
   browserify = require('browserify'),
   browserifyCache = require('browserify-cache-api'),
   babelify = require('babelify'),
+  babel = require('gulp-babel'),
   through2 = require('through2'),
   browserifyExtractRegistry = require('browserify-extract-registry'),
   browserifyExtractIds = require('browserify-extract-ids'),
@@ -88,6 +89,7 @@ function buildKiln() {
 function copyClientInit() {
   return h(gulp.src(path.join(__dirname, '_client-init.js'))
     .pipe(changed(destPath, { hasChanged: helpers.hasChanged }))
+    .pipe(babel(babelConfig))
     .pipe(replace('#NODE_ENV#', process.env.NODE_ENV || ''))
     .pipe(gulp.dest(destPath))
     .pipe(es.mapSync((file) => ({ type: 'success', message: file.path }))));

--- a/package-lock.json
+++ b/package-lock.json
@@ -4892,6 +4892,17 @@
         }
       }
     },
+    "gulp-babel": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-8.0.0.tgz",
+      "integrity": "sha512-oomaIqDXxFkg7lbpBou/gnUkX51/Y/M2ZfSjL2hdqXTAlSWZcgZtd2o0cOH0r/eE8LWD0+Q/PsLsr2DKOoqToQ==",
+      "requires": {
+        "plugin-error": "^1.0.1",
+        "replace-ext": "^1.0.0",
+        "through2": "^2.0.0",
+        "vinyl-sourcemaps-apply": "^0.2.0"
+      }
+    },
     "gulp-changed": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/gulp-changed/-/gulp-changed-3.2.0.tgz",
@@ -8035,6 +8046,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -8043,7 +8055,8 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "get-stdin": "^5.0.1",
     "glob": "^7.1.3",
     "gulp": "^4.0.0",
+    "gulp-babel": "^8.0.0",
     "gulp-changed": "^3.2.0",
     "gulp-concat": "^2.6.1",
     "gulp-cssmin": "^0.2.0",


### PR DESCRIPTION
### testing
1. in this repo, on this branch, `npm link`
2. in your sites repo, `npm link claycli`
3. In your sites app folder (wherever your `package.json` file lives), `clay compile scripts` then verify that the file at `app/public/_client-init.js` looks like it has been transpiled - for example the `for...of` loops will be replaced by something like this:
```js
      var _iteratorNormalCompletion = true;
      var _didIteratorError = false;
      var _iteratorError = undefined;

      try {
        for (var _iterator = instances[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
          var el = _step.value;
```