### PR TITLE
bugfix: enables CSS minification via environment variable

### DIFF
--- a/lib/cmd/compile/fonts.js
+++ b/lib/cmd/compile/fonts.js
@@ -149,7 +149,7 @@ function compile(options = {}) {
           .pipe(newer({ dest: path.join(destPath, 'css', `_inlined-fonts.${styleguide}.css`), ctime: true }))
           .pipe(es.mapSync((file) => getFontCSS(file, styleguide, true)))
           .pipe(concat(`_inlined-fonts.${styleguide}.css`))
-          .pipe(gulpIf(minify, cssmin()))
+          .pipe(gulpIf(Boolean(minify), cssmin()))
           .pipe(gulp.dest(path.join(destPath, 'css')))
           .pipe(es.mapSync((file) => ({ type: 'success', message: file.path })));
         streams.push(inlinedFontsTask);
@@ -165,7 +165,7 @@ function compile(options = {}) {
           .pipe(gulp.dest(path.join(destPath, 'fonts')))
           .pipe(es.mapSync((file) => getFontCSS(file, styleguide, false)))
           .pipe(concat(`_linked-fonts.${styleguide}.css`))
-          .pipe(gulpIf(minify, cssmin()))
+          .pipe(gulpIf(Boolean(minify), cssmin()))
           .pipe(gulp.dest(path.join(destPath, 'css')))
           .pipe(es.mapSync((file) => ({ type: 'success', message: file.path })));
         streams.push(linkedFontsTask);

--- a/lib/cmd/compile/styles.js
+++ b/lib/cmd/compile/styles.js
@@ -126,7 +126,7 @@ function compile(options = {}) {
         simpleVars({ variables }),
         nested()
       ].concat(plugins)))
-      .pipe(gulpIf(minify, cssmin()))
+      .pipe(gulpIf(Boolean(minify), cssmin()))
       .pipe(gulp.dest(destPath))
       .pipe(es.mapSync((file) => ({ type: 'success', message: path.basename(file.path) })));
   }


### PR DESCRIPTION
Setting `CLAYCLI_COMPILE_MINIFED` (or any of the variants) did *not*
minify CSS or Fonts. This was due to our use of a package called
`gulp-if`, which has a usage like this:

```js
gulpIf(condition, trueChild, falseChild, minmatchOptions);
```

Where `condition` is expected to either be:

1. A `boolean`.
2. A `function` that will return a `boolean`.

When setting `CLAYCLI_COMPILE_MINIFIED` from an environment variable we
end up with a `string` value for `minify`, which causes `gulpIf` to
evaluate to `false`, skipping minification.

This commit simply casts `minify` to a `bool` when calling `gulpIf`.

A more robust approach would be to fix typing across the board for
environment variable defaults, providing some sort of `strToBool`
method to cast `['1', 't', 'true', 'y', 'yes']` to `true` and
everything else to `false`.

Taking the more robust approach would require a larger refactor and is
a good follow-up candidate for this bug fix.

:warning: Note: There is not an existing test suite to validate this
change, all tests were performed manually by running `clay compile` on
an existing `clay` project with `export CLAYCLI_COMPILE_MINIFIED=true`
before the commit & then checking the format of the CSS output files
(they were not minified).

After adding the commit, re-running with `CLAYCLI_COMPILE_MINIFIED=true`
resulted in minified CSS output.