### PR TITLE
import the command you actually use

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -14,7 +14,15 @@ const yargs = require('yargs'),
   pkg = require('../package.json'),
   notifier = updateNotifier({
     pkg
-  });
+  }),
+  commands = {
+    cfg: 'config',
+    l: 'lint',
+    i: 'import',
+    e: 'export',
+    c: 'compile'
+  },
+  listCommands = Object.keys(commands).concat(Object.values(commands));
 
 if (notifier.update) {
   // note: this will only check for updates once per day
@@ -22,14 +30,22 @@ if (notifier.update) {
   process.exit(0);
 }
 
+let thisCommand = process.argv.filter(arg => listCommands.includes(arg))[0];
+
+if (!thisCommand) {
+  console.error('invalid command');
+  process.exit();
+}
+
+// convert alias to full command e.g. i -> import
+if (Object.keys(commands).includes(thisCommand)) {
+  thisCommand = commands[thisCommand];
+}
+
 yargs
   .usage('Usage: clay <command> [options]')
   .wrap(yargs.terminalWidth())
-  .command(require('./config'))
-  .command(require('./lint'))
-  .command(require('./import'))
-  .command(require('./export'))
-  .command(require('./compile'))
+  .command(require(`./${thisCommand}`))
   // common options
   .help()
   .version()


### PR DESCRIPTION
### Description of Changes
Claycli loads requirements for all of its commands even though only one is ever run. compile in particular takes a while to start up, so this PR parses the command line args and calls `require` only on that arg.

New:
```
$ time clay config -k local -r json
{"level":30,"time":1592346996492,"msg":"MadeUpAccessKey","pid":9274,"hostname":"Chase-Felker-MacBook-Pro.local","name":"claycli","claycliVersion":"3.12.1","command":"config","type":"info","_label":"INFO","v":1}

real	0m0.234s
user	0m0.176s
sys	0m0.058s
```

Old:
```
$ time clay config --key stage  --reporter json
{"level":30,"time":1592252061518,"msg":"your-key","pid":78980,"hostname":"Chase-Felker-MacBook-Pro.local","name":"claycli","claycliVersion":"3.12.1","command":"config","type":"info","_label":"INFO","v":1}
real	0m1.716s
user	0m1.560s
sys	0m0.420s
```