### PR TITLE
Introduces release workflow via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,144 @@
+---
 version: 2
-general:
-  artifacts:
-    - coverage
+
+references:
+
+  filter_all: &filter_all
+    filters:
+      branches:
+        only: /.*/
+      tags:
+        only: /.*/
+
+  filter_stg: &filter_head
+    filters:
+      branches:
+        only: master
+      tags:
+        only: stg
+
+  filter_prd: &filter_release
+    filters:
+      branches:
+        ignore: /.*/
+      tags:
+        only: /v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?/
+
 jobs:
-  build:
+
+  test_node10:
     docker:
-      - image: node:8.10.0
-    working_directory: ~/repo
-    parallelism: 4
+      - image: circleci/node:10
+    working_directory: ~/src
     steps:
       - checkout
-      # Download and cache dependencies
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+          - v2-node10-dependencies-{{ checksum "package.json" }}
+          - v2-node10-dependencies-
       - run: npm install
       - save_cache:
+          key: v2-node10-dependencies-{{ checksum "package.json" }}
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
-      # run tests
-      - run: npm test -- --maxWorkers=4
-      # send to coveralls
+      - run: npm test
+
+  test_node12:
+    docker:
+      - image: circleci/node:12
+    working_directory: ~/src
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v2-node12-dependencies-{{ checksum "package.json" }}
+          - v2-node12-dependencies-
+      - run: npm install
+      - save_cache:
+          key: v2-node12-dependencies-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run: npm test
       - run: cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+
+  test_node14:
+    docker:
+      - image: circleci/node:14
+    working_directory: ~/src
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v2-node14-dependencies-{{ checksum "package.json" }}
+          - v2-node14-dependencies-
+      - run: npm install
+      - save_cache:
+          key: v2-node14-dependencies-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run: npm test
+
+  deploy_docs:
+    docker:
+      - image: circleci/node:14
+    working_directory: ~/src
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-website-dependencies-{{ checksum "website/package.json" }}
+      - run:
+          name: Build
+          command: |
+            sudo apt-get -y install awscli
+            bash ./.circleci/scripts/deploy-docs.sh
+      - save_cache:
+          key: v1-website-dependencies-{{ checksum "website/package.json" }}
+          paths:
+            - website/node_modules
+
+  deploy_package:
+    docker:
+      - image: circleci/node:12
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v2-node12-dependencies-{{ checksum "package.json" }}
+          - v2-node12-dependencies-
+      - run: npm install
+      - run: |
+          echo "$NPMRC" > ~/.npmrc
+          chmod 600 ~/.npmrc
+          if [[ "$CIRCLE_TAG" = *-* ]]; then
+            npm publish --tag=prerelease
+          else
+            npm publish
+          fi
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test_node10:
+          <<: *filter_all
+      - test_node12:
+          <<: *filter_all
+      - test_node14:
+          <<: *filter_all
+      - deploy_docs:
+          <<: *filter_head
+          context:
+            - Documentation
+          requires:
+            - test_node10
+            - test_node12
+            - test_node14
+      - deploy_package:
+          <<: *filter_release
+          context:
+            - npm-publish
+          requires:
+            - test_node10
+            - test_node12
+            - test_node14

--- a/.circleci/scripts/deploy-docs.sh
+++ b/.circleci/scripts/deploy-docs.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e -o pipefail
+
+BUCKET=docs.clayplatform.io
+
+green(){
+    printf "\e[32m$1\e[39m\n"
+}
+
+red(){
+    >&2 printf "\e[31m$1\e[39m\n"
+}
+
+export PROJECT_NAME="${PROJECT_NAME:-$CIRCLE_PROJECT_REPONAME}"
+if [[ -z "$PROJECT_NAME" ]]; then
+    red "PROJECT_NAME not set and could not be derived from CIRCLE_PROJECT_REPONAME"
+    exit 1
+fi
+green "PROJECT_NAME: $PROJECT_NAME"
+
+export BUILD_DIR="${BUILD_DIR:-website}"
+green "BUILD_DIR: $BUILD_DIR"
+
+green "Building documentation..."
+cd "$BUILD_DIR"
+npm install --quiet
+npm run build
+
+green "Uploading documentation to $BUCKET..."
+aws s3 sync --delete --acl=public-read "build/$PROJECT_NAME/" "s3://$BUCKET/$PROJECT_NAME/"
+
+green "Documentation updated."

--- a/.circleci/scripts/release.sh
+++ b/.circleci/scripts/release.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This script will increment the package version in package.json.
+# It will then tag the HEAD of the master branch with the version number
+# and push the tag to the origin (GitHub)
+
+set -e
+
+OPTIONS="(prepatch|patch|preminor|minor|premajor|major)"
+USAGE="usage: npm release $OPTIONS"
+SEMVAR="$1"
+
+# Releases should only be cut from the master branch.
+# They can be manually cut from other branches, but that should be a very
+# intentional process.
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$BRANCH" != "master" ]]; then
+    >&2 echo "ERROR: Not on the master branch, will not release."
+    exit 1
+fi
+
+case $SEMVAR in
+    minor)
+        ;;
+    major)
+        ;;
+    patch)
+        ;;
+    premajor)
+        ;;
+    preminor)
+        ;;
+    prepatch)
+        ;;
+    *)
+        SEMVAR=prepatch
+        >&2 echo "WARNING: No $OPTIONS provided, defaulting to PREPATCH."
+        >&2 echo "$USAGE"
+        ;;
+esac
+
+git pull --rebase origin master
+version="$(npm version $SEMVAR)"
+git push origin master
+git push origin "tags/$version"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4538,9 +4538,9 @@
       }
     },
     "fstream": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -5642,9 +5642,9 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "in-publish": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
     },
     "indent-string": {
       "version": "2.1.0",
@@ -7663,16 +7663,6 @@
         "lodash._objecttypes": "~2.4.1"
       }
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -7729,11 +7719,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-    },
-    "lodash.mergewith": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
     },
     "lodash.restparam": {
       "version": "3.6.1",
@@ -8211,7 +8196,8 @@
     "nan": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -8323,12 +8309,12 @@
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
         },
         "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
           "requires": {
             "block-stream": "*",
-            "fstream": "^1.0.2",
+            "fstream": "^1.0.12",
             "inherits": "2"
           }
         }
@@ -8386,9 +8372,9 @@
       }
     },
     "node-sass": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
-      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.14.0.tgz",
+      "integrity": "sha512-AxqU+DFpk0lEz95sI6jO0hU0Rwyw7BXVEv6o9OItoXLyeygPeaSpiV4rwQb10JiTghHaa0gZeD21sz+OsQluaw==",
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -8397,12 +8383,10 @@
         "get-stdin": "^4.0.1",
         "glob": "^7.0.3",
         "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
+        "lodash": "^4.17.15",
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
+        "nan": "^2.13.2",
         "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "^2.88.0",
@@ -8432,6 +8416,16 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "nan": {
+          "version": "2.14.2",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+          "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
         },
         "supports-color": {
           "version": "2.0.0",
@@ -11721,9 +11715,9 @@
       }
     },
     "sass-graph": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.6.tgz",
+      "integrity": "sha512-MKuEYXFSGuRSi8FZ3A7imN1CeVn9Gpw0/SFJKdL1ejXJneI9a5rwlEZrKejhEFAA3O6yr3eIyl/WuvASvlT36g==",
       "requires": {
         "glob": "^7.0.0",
         "lodash": "^4.0.0",
@@ -11732,9 +11726,9 @@
       },
       "dependencies": {
         "yargs": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.1.tgz",
+          "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
           "requires": {
             "camelcase": "^3.0.0",
             "cliui": "^3.2.0",
@@ -11748,7 +11742,16 @@
             "string-width": "^1.0.2",
             "which-module": "^1.0.0",
             "y18n": "^3.2.1",
-            "yargs-parser": "^5.0.0"
+            "yargs-parser": "5.0.0-security.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0-security.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
+          "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
+          "requires": {
+            "camelcase": "^3.0.0",
+            "object.assign": "^4.1.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "js-yaml": "^3.10.0",
     "kew": "^0.7.0",
     "lodash": "^4.17.5",
-    "node-sass": "^4.9.3",
+    "node-sass": "^4.14.0",
     "nyansole": "^0.5.1",
     "plugin-error": "^1.0.1",
     "pluralize": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clay": "cli/index.js"
   },
   "scripts": {
-    "lint": "eslint --max-warnings 0 lib cli index.js",
+    "lint": "eslint lib cli index.js",
     "test": "npm run lint && jest",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "release": "./circleci/scripts/release.sh",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint --max-warnings 0 lib cli index.js",
     "test": "npm run lint && jest",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "release": "./circleci/scripts/release.sh",
     "watch": "jest --watch"
   },
   "jest": {


### PR DESCRIPTION
This commit introduces a new release workflow that ensures NPM packages are published in a consistent manner.

The typical workflow will involve creating a release from the **base** branch (currently: `master`).

1. Start by creating a prerelease candidate, selecting the correct version to increment.
```sh
npm run release (prepatch|preminor|premajor)
```

2. This will run `npm version (selection)` and push the branch/tag.

3. CircleCI will publish a package with `--tag=prerelease`, eg. `v8.17.1-0`.

4. When we are ready to promote a release from `prerelease` to `latest` run the following.
```sh
npm run release (patch|minor|major)
```

5. This will run `npm version (selection)` and push the branch/tag.

6. CircleCI will publish a package, eg `v8.17.1`.

---

:warning:

This pull request upgrades `node-sass` from v4.11.0 to v4.14.0.
The previous version only supported builds on node versions < 10.