### PR TITLE
Clean up development build patterns.

### DIFF
--- a/cli/pack/options.js
+++ b/cli/pack/options.js
@@ -6,7 +6,7 @@ module.exports = {
     {
       array: true,
       alias: ['g'],
-      default: ['./components/**/client.js'],
+      default: [],
       description: 'optional list of glob patterns to compile',
       type: 'array'
     }

--- a/cli/pack/scripts.js
+++ b/cli/pack/scripts.js
@@ -32,7 +32,9 @@ function handler(argv) {
     });
   }).then(compiler => {
     compiler.close(err => {
-      throw err;
+      if (err) {
+        throw err;
+      }
     });
   }).catch((err) => {
     log('error', 'Script compilation failed', {

--- a/cli/pack/scripts.js
+++ b/cli/pack/scripts.js
@@ -28,7 +28,11 @@ function handler(argv) {
         reject(new Error(msg));
       }
 
-      resolve();
+      resolve(compiler);
+    });
+  }).then(compiler => {
+    compiler.close(err => {
+      throw err;
     });
   }).catch((err) => {
     log('error', 'Script compilation failed', {

--- a/lib/cmd/pack/get-webpack-config.js
+++ b/lib/cmd/pack/get-webpack-config.js
@@ -30,10 +30,10 @@ const helpers = require('../../compilation-helpers');
   * Create a stateful webpack-chain configuration object and set sensible
  * defaults for a client-side build.
  *
- * @param {PackArgv} argv - Command-line options.
+ * @param {string[]} entrypoints - A list of globs which will serve as entrypoints.
  * @returns {Config} - A webpack-chain configuration object.
  */
-function createConfig(argv) {
+function createConfig(entrypoints) {
   /* eslint-disable indent --- It's easier to read config chains with extra indentation. */
 
   const config = new Config();
@@ -67,7 +67,7 @@ function createConfig(argv) {
    *
    * TODO: Document this more fully.
    */
-  const entry = argv.globs.reduce((entries, glob) => {
+  const componentEntries = entrypoints.reduce((entries, glob) => {
     const nextEntries = getEntrypoints(glob);
 
     return _.merge(entries, nextEntries);
@@ -79,7 +79,7 @@ function createConfig(argv) {
 
   config.merge({
     entry: {
-      ...entry,
+      ...componentEntries,
       __clay_client_init: path.join(__dirname, '_client-init.js'),
     },
   });
@@ -146,6 +146,23 @@ function createConfig(argv) {
           cleanOnceBeforeBuildPatterns: [
             'scripts/**/*'
           ]
+        }
+      ]);
+
+  /**
+   * Generate an asset manifest mapping source files to built assets. We ensure
+   * the manifest includes all entrypoints, each of which is a complete
+   * dependency chain for the source file.
+   *
+   * TODO: When Webpack's watch features are built out, we should enable this in
+   * development as well.
+   */
+  config
+    .plugin('asset-manifest')
+      .use(AssetManifestPlugin, [
+        {
+          entrypoints: true,
+          publicPath: true
         }
       ]);
 
@@ -264,6 +281,8 @@ function buildCustomConfig(config) {
  * @returns {Config} - The modified configuration object.
  */
 function buildDevelopmentConfig(config) {
+  /* eslint-disable indent --- It's easier to read config chains with extra indentation. */
+
   config
     .mode('development')
     .devtool('cheap-module-source-map');
@@ -275,6 +294,8 @@ function buildDevelopmentConfig(config) {
   config.optimization.merge({
     emitOnErrors: true
   });
+
+  /* eslint-enable indent */
 
   return config;
 }
@@ -313,23 +334,6 @@ function buildProductionConfig(config) {
   config
     .plugin('common-shake')
       .use(CommonShakePlugin);
-
-  /**
-   * Generate an asset manifest mapping source files to built assets. We ensure
-   * the manifest includes all entrypoints, each of which is a complete
-   * dependency chain for the source file.
-   *
-   * TODO: When Webpack's watch features are built out, we should enable this in
-   * development as well.
-   */
-  config
-    .plugin('asset-manifest')
-      .use(AssetManifestPlugin, [
-        {
-          entrypoints: true,
-          publicPath: true
-        }
-      ]);
 
   /* eslint-enable indent */
 
@@ -371,8 +375,8 @@ function getEntrypoints(glob) {
  * @param {PackArgv} argv - Command-line options.
  * @returns {Config} - The webpack-chain configuration object.
  */
-function getWebpackConfig(argv) {
-  let client = createConfig(argv); // TODO: Support serverside builds.
+function getWebpackConfig({ globs }) {
+  let client = createConfig(globs); // TODO: Support serverside builds.
 
   switch (process.env.CLAYCLI_COMPILE_MINIFIED) {
     case 'true':

--- a/lib/cmd/pack/get-webpack-config.js
+++ b/lib/cmd/pack/get-webpack-config.js
@@ -60,9 +60,13 @@ function createConfig(argv) {
     .name('clay-pack')
     .target('web'); // TODO: Support serverside builds with target "node".
 
-  // A mapping of pathnames to entrypoints. For now, we're assuming all the code
-  // we care about lives under the `components` module or the `global` module in
-  // the working directory and matches the filename `client.pack.js`.
+  /**
+   * A mapping of pathnames to entrypoints. For now, we're assuming all the code
+   * we care about lives under the `components` module or the `global` module in
+   * the working directory and matches the filename `client.pack.js`.
+   *
+   * TODO: Document this more fully.
+   */
   const entry = argv.globs.reduce((entries, glob) => {
     const nextEntries = getEntrypoints(glob);
 
@@ -99,23 +103,13 @@ function createConfig(argv) {
     .path(path.join(process.cwd(), './public'))
     .publicPath('/');
 
-  // Ensure `import` and `require` statements are case-sensitive, even on
-  // platforms (like macOS) which are not.
+  /**
+   * Ensure `import` and `require` statements are case-sensitive, even on
+   * platforms (like macOS) which are not.
+   */
   config
     .plugin('case-sensitive-paths')
       .use(CaseSensitivePathsPlugin);
-
-  // Generate an asset manifest mapping source files to built assets. We ensure
-  // the manifest includes all entrypoints, each of which is a complete
-  // dependency chain for the source file.
-  config
-    .plugin('asset-manifest')
-      .use(AssetManifestPlugin, [
-        {
-          entrypoints: true,
-          publicPath: true
-        }
-      ]);
 
   config
     .plugin('progress')
@@ -247,9 +241,11 @@ function buildCustomConfig(config) {
 
   const customConfig = customizer(config);
 
-  // `toConfig` is always defined on a webpack-chain configuration. A
-  // non-webpack-chain object with a `toConfig` method could still fool us, but
-  // that's not really our problem.
+  /**
+   * `toConfig` is always defined on a webpack-chain configuration. A
+   * non-webpack-chain object with a `toConfig` method could still fool us, but
+   * that's not really our problem.
+   */
   if (
     typeof customConfig !== 'object' ||
     typeof customConfig.toConfig !== 'function'
@@ -317,6 +313,23 @@ function buildProductionConfig(config) {
   config
     .plugin('common-shake')
       .use(CommonShakePlugin);
+
+  /**
+   * Generate an asset manifest mapping source files to built assets. We ensure
+   * the manifest includes all entrypoints, each of which is a complete
+   * dependency chain for the source file.
+   *
+   * TODO: When Webpack's watch features are built out, we should enable this in
+   * development as well.
+   */
+  config
+    .plugin('asset-manifest')
+      .use(AssetManifestPlugin, [
+        {
+          entrypoints: true,
+          publicPath: true
+        }
+      ]);
 
   /* eslint-enable indent */
 


### PR DESCRIPTION
Previously, we would always build Webpack modules alongside Browserify modules---even in development, where Webpack needs a little more love. This ensures we skip most of the manifest, so Amphora HTML falls back to to our legacy modules automatically.