### PR TITLE
Fix bug in component matcher.

### DIFF
--- a/lib/cmd/pack/_client-init.js
+++ b/lib/cmd/pack/_client-init.js
@@ -11,7 +11,7 @@ function mountComponentModules() {
   Object.keys(__webpack_modules__)
     .filter(moduleName => /components/.test(moduleName))
     .forEach(moduleName => {
-      const nameExp = /components\/([-A-za-z0-9]+?)\//i.exec(moduleName);
+      const nameExp = /components\/([-A-za-z0-9]+?)\/client/i.exec(moduleName);
 
       if (!nameExp) return;
 


### PR DESCRIPTION
Due to an improperly anchored regexp, the module initialization script kept trying to pass HTML elements to the exports of arbitrary modules. In the case of the subscription page, for instance, the init script kept passing `div.subscription-multi-step-container` to the default export of `./components/subscription-multi-step-container/services/isValidName.js`. 😶 