### PR TITLE
hacky changes to allow easier vue plugin development in nymag/sites

### DIFF
--- a/cli/compile/index.js
+++ b/cli/compile/index.js
@@ -35,7 +35,7 @@ function handler(argv) {
   const t1 = Date.now(),
     media = compile.media({ watch: argv.watch }); // run media task before others (specifically, templates)
 
-  return h(media.build).collect().toArray((mediaResults) => {
+  return h([]).toArray((mediaResults) => {
     const fonts = compile.fonts({
         watch: argv.watch,
         minify: argv.minify,
@@ -57,9 +57,9 @@ function handler(argv) {
         globs: argv.globs,
         reporter: argv.reporter
       }),
-      tasks = [fonts, styles, templates, scripts],
+      tasks = [scripts],
       builders = _.map(tasks, (task) => task.build),
-      watchers = _.map(tasks, (task) => task.watch).concat([media.watch]),
+      watchers = _.map(tasks, (task) => task.watch),
       isWatching = !!watchers[0];
 
     return h([h.of(mediaResults)].concat(builders))

--- a/lib/cmd/compile/scripts.js
+++ b/lib/cmd/compile/scripts.js
@@ -333,7 +333,8 @@ function buildScripts(entries, options = {}) {
 
   // speed up full rebuilds for developers
   if (!options.minify) {
-    browserifyCache(bundler, { cacheFile: browserifyCachePath });
+    // something in this browserifyCache call seems to be breaking compilation of vue plugin assets
+    // browserifyCache(bundler, { cacheFile: browserifyCachePath });
     // note: this file is NOT written in production environments
   }
 
@@ -436,17 +437,18 @@ function buildScripts(entries, options = {}) {
 function compile(options = {}) {
   const watch = options.watch || false,
     minify = options.minify || variables.minify || false,
-    globs = options.globs || [],
+    // globs = options.globs || [],
+    globs = [],
     reporter = options.reporter || 'pretty',
     globFiles = globs.length ? _.flatten(_.map(globs, (g) => glob.sync(path.join(process.cwd(), g)))) : [],
     // client.js, model.js, kiln plugins, and legacy global scripts are passed to megabundler
-    bundleEntries = glob.sync(componentClientsGlob).concat(
-      glob.sync(componentModelsGlob),
-      glob.sync(componentKilnGlob),
-      glob.sync(layoutClientsGlob),
-      glob.sync(layoutModelsGlob),
-      glob.sync(kilnPluginsGlob),
-      globFiles
+    bundleEntries = glob.sync(kilnPluginsGlob).concat(
+      // glob.sync(componentModelsGlob),
+      // glob.sync(componentKilnGlob),
+      // glob.sync(layoutClientsGlob),
+      // glob.sync(layoutModelsGlob),
+      // glob.sync(kilnPluginsGlob)
+      // globFiles
     ),
     // options are set beforehand, so we can grab the cached files to watch afterwards
     bundleOptions = { minify, legacyFiles: globFiles },
@@ -482,7 +484,9 @@ function compile(options = {}) {
              * would be removed from this deps file upon watch recompilation.
              * @see https://github.com/clay/claycli/issues/116#issuecomment-454110714
              */
-            buildScripts(bundleOptions.cache.files, bundleOptions)
+            // limiting entrypoints to kiln directory files
+            let cacheFiles = bundleOptions.cache.files.filter(item => item.match(/\/kiln\//));
+            buildScripts( cacheFiles, bundleOptions)
               .then(function (result) {
                 _.map(result, reporters.logAction(reporter, 'compile'));
               });


### PR DESCRIPTION
Vue plugin compilation is somewhat broken in [nymag/sites](https://github.com/nymag/sites), due to some aspect of our browserify cache implementation. When compiling assets with claycli, files such as `css/_kiln-plugins.css` and `js/_kiln-plugins.js` will be not be completely compiled, often containing the assets for the `.vue` file that was most recently touched.

The issue is also documented [here](https://github.com/clay/claycli/issues/201).

This PR is **not** meant to be merged, but offers developers who are touching kiln-plugin files often an alternate workflow.