### PR TITLE
catches template compile errors when watching

### DIFF
--- a/lib/cmd/compile/templates.js
+++ b/lib/cmd/compile/templates.js
@@ -126,7 +126,7 @@ function precompile(file) {
     return file;
   } catch (e) {
     console.log(chalk.red(`Error precompiling template "${name}": `) + e.message);
-    process.exit(1);
+    throw e;
   }
 }
 
@@ -218,6 +218,11 @@ function compile(options = {}) {
       */
       .pipe(es.mapSync(wrapTemplate))
       .pipe(es.mapSync(precompile))
+      .on('error', (err) => {
+        if (!watch) {
+          throw err;
+        }
+      })
       .pipe(es.mapSync(registerTemplate))
       .pipe(es.mapSync((file) => minifyTemplate(file, minify)))
       .pipe(concatTemplates()) // when minifying, concat to '_templates-<letter>-<letter>.js'


### PR DESCRIPTION
Very small improvement, but it's nice to not have to restart watch if you make a typo in a template.