### PR TITLE
fix: fetch undici agent support, node 16+

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -1,17 +1,20 @@
-/* global fetch:false */
-
 'use strict';
+
 const h = require('highland'),
   _ = require('lodash'),
   nodeUrl = require('url'),
-  https = require('https'),
+  { Agent } = require('undici'),
   b64 = require('base-64'),
   pluralize = require('pluralize'),
-  agent = new https.Agent({ rejectUnauthorized: false }), // allow self-signed certs
   CONTENT_TYPES = {
     json: 'application/json; charset=UTF-8',
     text: 'text/plain; charset=UTF-8'
-  };
+  },
+  agent = new Agent({
+    connect: {
+      rejectUnauthorized: false,
+    }
+  });
 
 // isormorphic-fetch sets a global
 require('isomorphic-fetch');
@@ -77,7 +80,7 @@ function get(url, options = {}) {
   return h(send(url, {
     method: 'GET',
     headers: options.headers,
-    agent: isSSL(url) ? agent : null
+    dispatcher: isSSL(url) ? agent : null
   }).then((res) => {
     if (res instanceof Error) {
       res.url = url; // capture urls that we error on
@@ -124,7 +127,7 @@ function put(url, data, options = {}) {
     method: 'PUT',
     body: body,
     headers: headers,
-    agent: isSSL(url) ? agent : null
+    dispatcher: isSSL(url) ? agent : null
   }).then((res) => {
     if (res instanceof Error) {
       return { type: 'error', details: url, message: res.message };
@@ -160,7 +163,7 @@ function query(url, query, options = {}) {
     method: 'POST',
     body: JSON.stringify(query),
     headers: headers,
-    agent: isSSL(url) ? agent : null
+    dispatcher: isSSL(url) ? agent : null
   }).then((res) => {
     if (res instanceof Error) {
       return { type: 'error', details: url, message: res.message };
@@ -217,7 +220,7 @@ function recursivelyCheckURI(currentURL, publicURI, options) {
   return send(possibleUrl, {
     method: 'GET',
     headers: options.headers,
-    agent: isSSL(possibleUrl) ? agent : null
+    dispatcher: isSSL(possibleUrl) ? agent : null
   }).then((res) => res.text())
     .then((uri) => ({ uri, prefix: possiblePrefix })) // return page uri and the prefix we discovered
     .catch(() => {
@@ -253,7 +256,7 @@ function findURI(url, options = {}) {
 function isElasticPrefix(url) {
   return h(send(`${url}/_components`, {
     method: 'GET',
-    agent: isSSL(url) ? agent : null
+    dispatcher: isSSL(url) ? agent : null
   }).then((res) => {
     if (res instanceof Error) {
       return false;

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -16,9 +16,6 @@ const h = require('highland'),
     }
   });
 
-// isormorphic-fetch sets a global
-require('isomorphic-fetch');
-
 /**
  * get protocol to determine if we need https agent
  * @param {string} url
@@ -26,6 +23,15 @@ require('isomorphic-fetch');
  */
 function isSSL(url) {
   return nodeUrl.parse(url).protocol === 'https:';
+}
+
+/**
+ * returns the fetch dispatcher by url protocol
+ * @param {string} url
+ * @returns {Agent}
+ */
+function getDispatcherByUrl(url) {
+  return isSSL(url) ? agent : new Agent();
 }
 
 /**
@@ -80,7 +86,7 @@ function get(url, options = {}) {
   return h(send(url, {
     method: 'GET',
     headers: options.headers,
-    dispatcher: isSSL(url) ? agent : null
+    dispatcher: getDispatcherByUrl(url)
   }).then((res) => {
     if (res instanceof Error) {
       res.url = url; // capture urls that we error on
@@ -127,7 +133,7 @@ function put(url, data, options = {}) {
     method: 'PUT',
     body: body,
     headers: headers,
-    dispatcher: isSSL(url) ? agent : null
+    dispatcher: getDispatcherByUrl(url)
   }).then((res) => {
     if (res instanceof Error) {
       return { type: 'error', details: url, message: res.message };
@@ -163,7 +169,7 @@ function query(url, query, options = {}) {
     method: 'POST',
     body: JSON.stringify(query),
     headers: headers,
-    dispatcher: isSSL(url) ? agent : null
+    dispatcher: getDispatcherByUrl(url)
   }).then((res) => {
     if (res instanceof Error) {
       return { type: 'error', details: url, message: res.message };
@@ -220,7 +226,7 @@ function recursivelyCheckURI(currentURL, publicURI, options) {
   return send(possibleUrl, {
     method: 'GET',
     headers: options.headers,
-    dispatcher: isSSL(possibleUrl) ? agent : null
+    dispatcher: getDispatcherByUrl(possibleUrl)
   }).then((res) => res.text())
     .then((uri) => ({ uri, prefix: possiblePrefix })) // return page uri and the prefix we discovered
     .catch(() => {
@@ -256,13 +262,9 @@ function findURI(url, options = {}) {
 function isElasticPrefix(url) {
   return h(send(`${url}/_components`, {
     method: 'GET',
-    dispatcher: isSSL(url) ? agent : null
+    dispatcher: getDispatcherByUrl(url)
   }).then((res) => {
-    if (res instanceof Error) {
-      return false;
-    } else {
-      return true;
-    }
+    return !(res instanceof Error);
   }));
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
         "webpack": "^5.32.0",
         "webpack-assets-manifest": "^5.0.4",
         "webpack-chain": "^6.5.1",
-        "yargs": "^16.2.0"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "clay": "cli/index.js"
@@ -19032,7 +19032,6 @@
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -19043,7 +19042,6 @@
     "node_modules/strip-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -21527,19 +21525,20 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
@@ -21557,15 +21556,9 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/yargs/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -21578,16 +21571,21 @@
       }
     },
     "node_modules/yargs/node_modules/cliui": {
-      "version": "7.0.4",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yargs/node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -21598,10 +21596,12 @@
     },
     "node_modules/yargs/node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/yargs/node_modules/get-caller-file": {
@@ -21613,6 +21613,7 @@
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
@@ -21620,6 +21621,7 @@
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -21630,18 +21632,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/yargs/node_modules/wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -21663,10 +21656,11 @@
       }
     },
     "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     }
   },
@@ -35890,15 +35884,13 @@
     "strip-ansi": {
       "version": "6.0.1",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       },
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.1",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-          "dev": true
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         }
       }
     },
@@ -37739,40 +37731,40 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
     },
     "yargs": {
-      "version": "16.2.0",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "requires": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
         "ansi-styles": {
           "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "cliui": {
-          "version": "7.0.4",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "requires": {
             "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
+            "strip-ansi": "^6.0.1",
             "wrap-ansi": "^7.0.0"
           }
         },
         "color-convert": {
           "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "requires": {
             "color-name": "~1.1.4"
@@ -37780,10 +37772,12 @@
         },
         "color-name": {
           "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "emoji-regex": {
           "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "get-caller-file": {
@@ -37792,10 +37786,12 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
           "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -37803,15 +37799,9 @@
             "strip-ansi": "^6.0.1"
           }
         },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        },
         "wrap-ansi": {
           "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
           "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "requires": {
             "ansi-styles": "^4.0.0",
@@ -37824,8 +37814,9 @@
           "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         },
         "yargs-parser": {
-          "version": "20.2.9",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "through2": "^4.0.2",
         "uglify-js": "^3.4.6",
         "uglifyify": "^5.0.2",
+        "undici": "^6.19.8",
         "unreachable-branch-transform": "^0.5.1",
         "update-notifier": "^5.1.0",
         "vue-loader": "^15.9.6",
@@ -20390,6 +20391,14 @@
       "version": "1.1.4",
       "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw=="
     },
+    "node_modules/undici": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
@@ -36865,6 +36874,11 @@
     "undertaker-registry": {
       "version": "1.0.1",
       "integrity": "sha512-UR1khWeAjugW3548EfQmL9Z7pGMlBgXteQpr1IZeZBtnkCJQJIJ1Scj0mb9wQaPvUZ9Q17XqW6TIaPchJkyfqw=="
+    },
+    "undici": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g=="
     },
     "undici-types": {
       "version": "5.26.5",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "through2": "^4.0.2",
     "uglify-js": "^3.4.6",
     "uglifyify": "^5.0.2",
+    "undici": "^6.19.8",
     "unreachable-branch-transform": "^0.5.1",
     "update-notifier": "^5.1.0",
     "vue-loader": "^15.9.6",


### PR DESCRIPTION
since node 16 node's built-in `fetch()` global does not use the HTTP stack provided by the traditional built-in `http/https` modules. We relied on those modules to handle local self-sign SSL certificate requests against clay sites. 

**Problem:** import commands using any version of node higher or equal to 16 against a local clay instance fail.
e.g.: export | import using node 20
![image](https://github.com/user-attachments/assets/e0f0abb3-a8f2-4cf5-b109-8d10bcddcbb2)

after this fix:
![image](https://github.com/user-attachments/assets/abf0c742-6060-43b0-86c1-518f1462c706)
