### PR TITLE
🍕 Fix export/import when a page has a url property

### DIFF
--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -28,7 +28,7 @@ function add(dispatch, prefix) {
     } else {
       return Promise.resolve(`"${prefix}/_${type}${name}`);
     }
-  }).then((prefixedString) => replace(prefixedString, /"customUrl":"(.*)"/g, (match, uri) => Promise.resolve(`"customUrl":"${urlPrefix}${uri}"`)))).map(JSON.parse);
+  }).then((prefixedString) => replace(prefixedString, /"customUrl":"(.*)"/g, (match, uri) => Promise.resolve(`"customUrl":"${urlPrefix}${uri}"`))).then((prefixedString) => replace(prefixedString, /"url":"(.*)"/g, (match, uri) => Promise.resolve(`"url":"${urlPrefix}${uri}"`)))).map(JSON.parse);
 }
 
 /**
@@ -53,7 +53,7 @@ function remove(dispatch, prefix) {
     } else {
       return Promise.resolve(`"/_${type}/${end}"`);
     }
-  }).then((unprefixedString) => replace(unprefixedString, /"customUrl":"(.*)"/g, (match, prefixedURI) => Promise.resolve(`"customUrl":"${prefixedURI.replace(urlPrefix, '')}"`)))).map(JSON.parse);
+  }).then((unprefixedString) => replace(unprefixedString, /"customUrl":"(.*)"/g, (match, prefixedURI) => Promise.resolve(`"customUrl":"${prefixedURI.replace(urlPrefix, '')}"`))).then((str) => replace(str, /"url":"(.*)"/g, (match, prefixedURI) => Promise.resolve(`"url":"${prefixedURI.replace(urlPrefix, '')}"`)))).map(JSON.parse);
 }
 
 /**

--- a/lib/prefixes.js
+++ b/lib/prefixes.js
@@ -28,7 +28,7 @@ function add(dispatch, prefix) {
     } else {
       return Promise.resolve(`"${prefix}/_${type}${name}`);
     }
-  }).then((prefixedString) => replace(prefixedString, /"customUrl":"(.*)"/g, (match, uri) => Promise.resolve(`"customUrl":"${urlPrefix}${uri}"`))).then((prefixedString) => replace(prefixedString, /"url":"(.*)"/g, (match, uri) => Promise.resolve(`"url":"${urlPrefix}${uri}"`)))).map(JSON.parse);
+  }).then((prefixedString) => replace(prefixedString, /"(customUrl|url)":"(.*)"/g, (match, prop, uri) => Promise.resolve(`"${prop}":"${urlPrefix}${uri}"`)))).map(JSON.parse);
 }
 
 /**
@@ -53,7 +53,7 @@ function remove(dispatch, prefix) {
     } else {
       return Promise.resolve(`"/_${type}/${end}"`);
     }
-  }).then((unprefixedString) => replace(unprefixedString, /"customUrl":"(.*)"/g, (match, prefixedURI) => Promise.resolve(`"customUrl":"${prefixedURI.replace(urlPrefix, '')}"`))).then((str) => replace(str, /"url":"(.*)"/g, (match, prefixedURI) => Promise.resolve(`"url":"${prefixedURI.replace(urlPrefix, '')}"`)))).map(JSON.parse);
+  }).then((unprefixedString) => replace(unprefixedString, /"(customUrl|url)":"(.*)"/g, (match, prop, prefixedURI) => Promise.resolve(`"${prop}":"${prefixedURI.replace(urlPrefix, '')}"`)))).map(JSON.parse);
 }
 
 /**

--- a/lib/prefixes.test.js
+++ b/lib/prefixes.test.js
@@ -94,6 +94,26 @@ describe('prefixes', () => {
       });
     });
 
+    it('adds prefix to url', () => {
+      return lib.add({
+        '/_pages/abc': { url: '/' }
+      }, `http://${prefix}`).toPromise(Promise).then((res) => {
+        expect(res).toEqual({
+          'domain.com/_pages/abc': { url: 'http://domain.com/' }
+        });
+      });
+    });
+
+    it('adds prefix to ssl url', () => {
+      return lib.add({
+        '/_pages/abc': { url: '/' }
+      }, `https://${prefix}`).toPromise(Promise).then((res) => {
+        expect(res).toEqual({
+          'domain.com/_pages/abc': { url: 'https://domain.com/' }
+        });
+      });
+    });
+
     it('does not mess up non-clay data', () => {
       return lib.add({
         '/_components/paragraph/instances/example': { text: 'Sanjay Srivastava <a href=\"http://pages.uoregon.edu/sanjay/bigfive.html#whatisit\" target=\"_blank\">explains on his website</a>, each' }
@@ -192,6 +212,26 @@ describe('prefixes', () => {
       }, `https://${prefix}`).toPromise(Promise).then((res) => {
         expect(res).toEqual({
           '/_pages/abc': { customUrl: '/' }
+        });
+      });
+    });
+
+    it('removes prefix from url', () => {
+      return lib.remove({
+        'domain.com/_pages/abc': { url: 'http://domain.com/' }
+      }, `http://${prefix}`).toPromise(Promise).then((res) => {
+        expect(res).toEqual({
+          '/_pages/abc': { url: '/' }
+        });
+      });
+    });
+
+    it('removes prefix from ssl url', () => {
+      return lib.remove({
+        'domain.com/_pages/abc': { url: 'https://domain.com/' }
+      }, `https://${prefix}`).toPromise(Promise).then((res) => {
+        expect(res).toEqual({
+          '/_pages/abc': { url: '/' }
         });
       });
     });

--- a/lib/prefixes.test.js
+++ b/lib/prefixes.test.js
@@ -94,23 +94,27 @@ describe('prefixes', () => {
       });
     });
 
-    it('adds prefix to url', () => {
-      return lib.add({
-        '/_pages/abc': { url: '/' }
-      }, `http://${prefix}`).toPromise(Promise).then((res) => {
-        expect(res).toEqual({
-          'domain.com/_pages/abc': { url: 'http://domain.com/' }
-        });
+    it('adds target hostname to page url on import', async () => {
+      // a page exported from any site has its hostname stripped, leaving a relative path
+      // on import, the target hostname should be prepended to reconstruct the full url
+      const exportedPage = { '/_pages/abc': { url: '/some-article' } };
+      const targetPrefix = `http://${prefix}`;
+
+      const result = await lib.add(exportedPage, targetPrefix).toPromise(Promise);
+
+      expect(result).toEqual({
+        'domain.com/_pages/abc': { url: 'http://domain.com/some-article' }
       });
     });
 
-    it('adds prefix to ssl url', () => {
-      return lib.add({
-        '/_pages/abc': { url: '/' }
-      }, `https://${prefix}`).toPromise(Promise).then((res) => {
-        expect(res).toEqual({
-          'domain.com/_pages/abc': { url: 'https://domain.com/' }
-        });
+    it('adds target https hostname to page url on import', async () => {
+      const exportedPage = { '/_pages/abc': { url: '/some-article' } };
+      const targetPrefix = `https://${prefix}`;
+
+      const result = await lib.add(exportedPage, targetPrefix).toPromise(Promise);
+
+      expect(result).toEqual({
+        'domain.com/_pages/abc': { url: 'https://domain.com/some-article' }
       });
     });
 
@@ -216,23 +220,27 @@ describe('prefixes', () => {
       });
     });
 
-    it('removes prefix from url', () => {
-      return lib.remove({
-        'domain.com/_pages/abc': { url: 'http://domain.com/' }
-      }, `http://${prefix}`).toPromise(Promise).then((res) => {
-        expect(res).toEqual({
-          '/_pages/abc': { url: '/' }
-        });
+    it('strips source hostname from page url on export', async () => {
+      // when exporting, the source hostname is removed from the page url
+      // leaving a relative path so it can be remapped on import to any target
+      const sourcePage = { 'domain.com/_pages/abc': { url: 'http://domain.com/some-article' } };
+      const sourcePrefix = `http://${prefix}`;
+
+      const result = await lib.remove(sourcePage, sourcePrefix).toPromise(Promise);
+
+      expect(result).toEqual({
+        '/_pages/abc': { url: '/some-article' }
       });
     });
 
-    it('removes prefix from ssl url', () => {
-      return lib.remove({
-        'domain.com/_pages/abc': { url: 'https://domain.com/' }
-      }, `https://${prefix}`).toPromise(Promise).then((res) => {
-        expect(res).toEqual({
-          '/_pages/abc': { url: '/' }
-        });
+    it('strips source https hostname from page url on export', async () => {
+      const sourcePage = { 'domain.com/_pages/abc': { url: 'https://domain.com/some-article' } };
+      const sourcePrefix = `https://${prefix}`;
+
+      const result = await lib.remove(sourcePage, sourcePrefix).toPromise(Promise);
+
+      expect(result).toEqual({
+        '/_pages/abc': { url: '/some-article' }
       });
     });
 

--- a/lib/prefixes.test.js
+++ b/lib/prefixes.test.js
@@ -74,23 +74,27 @@ describe('prefixes', () => {
       });
     });
 
-    it('adds prefix to customUrl', () => {
-      return lib.add({
-        '/_pages/abc': { customUrl: '/' }
-      }, `http://${prefix}`).toPromise(Promise).then((res) => {
-        expect(res).toEqual({
-          'domain.com/_pages/abc': { customUrl: 'http://domain.com/' }
-        });
+    it('adds target hostname to page customUrl on import', async () => {
+      // a page exported from any site has its hostname stripped, leaving a relative path
+      // on import, the target hostname should be prepended to reconstruct the full url
+      const exportedPage = { '/_pages/abc': { customUrl: '/some-article' } };
+      const targetPrefix = `http://${prefix}`;
+
+      const result = await lib.add(exportedPage, targetPrefix).toPromise(Promise);
+
+      expect(result).toEqual({
+        'domain.com/_pages/abc': { customUrl: 'http://domain.com/some-article' }
       });
     });
 
-    it('adds prefix to ssl customUrl', () => {
-      return lib.add({
-        '/_pages/abc': { customUrl: '/' }
-      }, `https://${prefix}`).toPromise(Promise).then((res) => {
-        expect(res).toEqual({
-          'domain.com/_pages/abc': { customUrl: 'https://domain.com/' }
-        });
+    it('adds target https hostname to page customUrl on import', async () => {
+      const exportedPage = { '/_pages/abc': { customUrl: '/some-article' } };
+      const targetPrefix = `https://${prefix}`;
+
+      const result = await lib.add(exportedPage, targetPrefix).toPromise(Promise);
+
+      expect(result).toEqual({
+        'domain.com/_pages/abc': { customUrl: 'https://domain.com/some-article' }
       });
     });
 
@@ -200,23 +204,27 @@ describe('prefixes', () => {
       });
     });
 
-    it('removes prefix from customUrl', () => {
-      return lib.remove({
-        'domain.com/_pages/abc': { customUrl: 'http://domain.com/' }
-      }, `http://${prefix}`).toPromise(Promise).then((res) => {
-        expect(res).toEqual({
-          '/_pages/abc': { customUrl: '/' }
-        });
+    it('strips source hostname from page customUrl on export', async () => {
+      // when exporting, the source hostname is removed from the page customUrl
+      // leaving a relative path so it can be remapped on import to any target
+      const sourcePage = { 'domain.com/_pages/abc': { customUrl: 'http://domain.com/some-article' } };
+      const sourcePrefix = `http://${prefix}`;
+
+      const result = await lib.remove(sourcePage, sourcePrefix).toPromise(Promise);
+
+      expect(result).toEqual({
+        '/_pages/abc': { customUrl: '/some-article' }
       });
     });
 
-    it('removes prefix from ssl customUrl', () => {
-      return lib.remove({
-        'domain.com/_pages/abc': { customUrl: 'https://domain.com/' }
-      }, `https://${prefix}`).toPromise(Promise).then((res) => {
-        expect(res).toEqual({
-          '/_pages/abc': { customUrl: '/' }
-        });
+    it('strips source https hostname from page customUrl on export', async () => {
+      const sourcePage = { 'domain.com/_pages/abc': { customUrl: 'https://domain.com/some-article' } };
+      const sourcePrefix = `https://${prefix}`;
+
+      const result = await lib.remove(sourcePage, sourcePrefix).toPromise(Promise);
+
+      expect(result).toEqual({
+        '/_pages/abc': { customUrl: '/some-article' }
       });
     });
 


### PR DESCRIPTION
Previously, the `url` property on page data (the page's public URL) was
passed through unchanged during export and import. This meant importing a
page to a different environment would leave the `url` pointing to the
source environment's hostname.

`add()` and `remove()` in `lib/prefixes.js` now transform the `"url"`
property in dispatches the same way `"customUrl"` is already handled:
- On export (`remove`): strips the source site prefix, leaving a relative
  path (e.g. `http://nymag.com/article/foo` → `/article/foo`)
- On import (`add`): prepends the target site prefix to restore a full URL
  (e.g. `/article/foo` → `http://staging.nymag.com/article/foo`)

Four tests added covering HTTP and HTTPS variants for both `add` and
`remove`.
