### PR TITLE
Show public URLs in import summary for _uris imports

### DIFF
--- a/cli/import.js
+++ b/cli/import.js
@@ -2,6 +2,8 @@
 const _ = require('lodash'),
   pluralize = require('pluralize'),
   chalk = require('chalk'),
+  b64 = require('base-64'),
+  nodeUrl = require('url'),
   options = require('./cli-options'),
   reporter = require('../lib/reporters'),
   importItems = require('../lib/cmd/import');
@@ -45,10 +47,21 @@ function handler(argv) {
       }
     })
     .toArray((results) => {
-      const pages = _.map(_.filter(results, (result) => result.type === 'success' && _.includes(result.message, 'pages')), (page) => `${page.message}.html`);
+      const protocol = nodeUrl.parse(argv.url).protocol || 'https:',
+        pages = _.map(_.filter(results, (result) => result.type === 'success' && _.includes(result.message, 'pages')), (page) => `${page.message}.html`),
+        publicUrls = _.map(
+          _.filter(results, (result) => result.type === 'success' && _.includes(result.message, '_uris/')),
+          (result) => {
+            const encoded = result.message.split('/_uris/')[1];
+
+            return `${protocol}//${b64.decode(encoded)}`;
+          }
+        );
 
       reporter.logSummary(argv.reporter, 'import', (successes) => {
-        if (successes && pages.length) {
+        if (successes && pages.length && publicUrls.length) {
+          return { success: true, message: `Imported ${pluralize('page', pages.length, true)}\n${chalk.gray(pages.join('\n'))}\n${chalk.cyan('Public URL(s):\n' + publicUrls.join('\n'))}` };
+        } else if (successes && pages.length) {
           return { success: true, message: `Imported ${pluralize('page', pages.length, true)}\n${chalk.gray(pages.join('\n'))}` };
         } else if (successes) {
           return { success: true, message: `Imported ${pluralize('uri', successes, true)}` };


### PR DESCRIPTION
## Summary
- decode imported `_uris` keys in `cli/import.js` and derive public-facing URLs
- include a `Public URL(s)` section in import summary output when page imports also succeed
- preserve existing summary behavior when no `_uris` entries are present

## Test plan
- [ ] run `clay import --yaml ...` with `_pages` + `_uris` entries and confirm summary prints public URLs
- [ ] run import without `_uris` entries and confirm summary output remains unchanged
- [ ] run import with only `_uris` entries and confirm existing uri count summary still works

Made with [Cursor](https://cursor.com)