### PR TITLE
Fix missing aws-region input in CI deploy-docs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION || 'us-east-1' }}
 
       - name: Deploy docs
         run: bash ./.github/scripts/deploy-docs.sh


### PR DESCRIPTION
## Summary
- update `aws-region` in `.github/workflows/ci.yml` to use a fallback expression:
  - `${{ secrets.AWS_DEFAULT_REGION || 'us-east-1' }}`

## Why
`aws-actions/configure-aws-credentials@v4` fails when `aws-region` resolves to an empty value. This ensures the job always supplies a valid region even when `AWS_DEFAULT_REGION` is not configured.

## Test plan
- Trigger CI on this branch
- Verify `deploy-docs` no longer fails with `Input required and not supplied: aws-region`

Made with [Cursor](https://cursor.com)